### PR TITLE
New keybinding 'o' to always stop playing

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -327,7 +327,7 @@ int main (int argc, char **argv) {
 							BarUiActDeleteStation, BarUiActExplain,
 							BarUiActStationFromGenre, BarUiActHistory,
 							BarUiActSongInfo, BarUiActAddSharedStation,
-							BarUiActMoveSong, BarUiActSkipSong, BarUiActPause,
+							BarUiActMoveSong, BarUiActSkipSong, BarUiActStop, BarUiActPause,
 							BarUiActQuit, BarUiActRenameStation,
 							BarUiActSelectStation, BarUiActTempBanSong,
 							BarUiActPrintUpcoming, BarUiActSelectQuickMix,

--- a/src/pianobar.1
+++ b/src/pianobar.1
@@ -97,6 +97,10 @@ Move current song to another station
 Skip current song.
 
 .TP
+.B act_songstop = o
+Stop the song, never continue.
+
+.TP
 .B act_songpause = p
 Pause/Continue
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -90,14 +90,14 @@ void BarSettingsRead (BarSettings_t *settings) {
 	FILE *configfd;
 	/* _must_ have same order as in BarKeyShortcutId_t */
 	static const char defaultKeys[] = {'?', '+', '-', 'a', 'c', 'd', 'e', 'g',
-			'h', 'i', 'j', 'm', 'n', 'p', 'q', 'r', 's', 't', 'u', 'x', '$',
+			'h', 'i', 'j', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'x', '$',
 			'b',
 			};
 	static const char *shortcutFileKeys[] = {
 			"act_help", "act_songlove", "act_songban", "act_stationaddmusic",
 			"act_stationcreate", "act_stationdelete", "act_songexplain",
 			"act_stationaddbygenre", "act_history", "act_songinfo",
-			"act_addshared", "act_songmove", "act_songnext", "act_songpause",
+			"act_addshared", "act_songmove", "act_songnext", "act_songstop", "act_songpause",
 			"act_quit", "act_stationrename", "act_stationchange",
 			"act_songtired", "act_upcoming", "act_stationselectquickmix",
 			"act_debug", "act_bookmark",

--- a/src/settings.h
+++ b/src/settings.h
@@ -52,8 +52,9 @@ typedef enum {
 	BAR_KS_SELECTQUICKMIX = 19,
 	BAR_KS_DEBUG = 20,
 	BAR_KS_BOOKMARK = 21,
+	BAR_KS_SONGSTOP = 22,
 	/* insert new shortcuts _before_ this element and increase its value */
-	BAR_KS_COUNT = 22,
+	BAR_KS_COUNT = 23,
 } BarKeyShortcutId_t;
 
 typedef enum {

--- a/src/ui_act.c
+++ b/src/ui_act.c
@@ -94,6 +94,7 @@ BarUiActCallback(BarUiActHelp) {
 			"add shared station",
 			"move song to different station",
 			"next song",
+			"stop playing, always pause, never continue",
 			"pause/continue",
 			"quit",
 			"rename current station",
@@ -348,6 +349,13 @@ BarUiActCallback(BarUiActMoveSong) {
 		}
 		BarUiActDefaultEventcmd ("songmove");
 	}
+}
+
+/*	pause
+ */
+BarUiActCallback(BarUiActStop) {
+	/* pause if locked, if locked, stay paused */
+	pthread_mutex_trylock (&app->player.pauseMutex);
 }
 
 /*	pause

--- a/src/ui_act.h
+++ b/src/ui_act.h
@@ -50,5 +50,6 @@ BarUiActCallback(BarUiActQuit);
 BarUiActCallback(BarUiActDebug);
 BarUiActCallback(BarUiActHistory);
 BarUiActCallback(BarUiActBookmark);
+BarUiActCallback(BarUiActStop);
 
 #endif /* _UI_ACT_H */


### PR DESCRIPTION
This is handy for me because I have a script to lock my computer and I want to always stop playing. So if pianobar is already stopped, I don't want it to start when I run my locking script.

Sorry the formatting is probably a little off. An astyle format config or something would've helped me get the formatting (line-width and such) perfect.
