### PR TITLE
commands case: upper case commands work just like lower case counter parts

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -154,6 +154,7 @@ static void BarMainHandleUserInput (BarApp_t *app) {
 	char buf[2];
 	if (BarReadline (buf, sizeof (buf), NULL, &app->input,
 			BAR_RL_FULLRETURN | BAR_RL_NOECHO, 1) > 0) {
+		buf[0] = tolower(buf[0]);
 		for (size_t i = 0; i < BAR_KS_COUNT; i++) {
 			if (app->settings.keys[i] != BAR_KS_DISABLED &&
 					app->settings.keys[i] == buf[0]) {


### PR DESCRIPTION
I noticed that if you type in a command (by which I mean 'n', 'p', '+', etc.) and the caps lock is on, the commands are silently eaten. As there aren't any commands that are upper case, I thought it'd be possible to just convert them all to lower-case.

I went ahead and made this fork to see how well it works. I think that it might be desirable from the user's perspective, so I thought I'd share it with you. If you feel that its worthwhile, go ahead and include it, if not no problem.

Thanks,
Matthew A. Todd

p.s: yes I know its a bit for a change of one line, but I thought it'd be easier to do it myself really fast.
