### PR TITLE
Fix the linking order so the --as-needed flag works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,9 @@ pianobar: ${PIANOBAR_OBJ} ${PIANOBAR_HDR} libpiano.so.0
 else
 pianobar: ${PIANOBAR_OBJ} ${PIANOBAR_HDR} ${LIBPIANO_OBJ} ${LIBWAITRESS_OBJ} \
 		${LIBWAITRESS_HDR} ${LIBEZXML_OBJ} ${LIBEZXML_HDR}
-	${CC} ${CFLAGS} ${LDFLAGS} -lao -lpthread -lm ${LIBFAAD_LDFLAGS} \
-			${LIBMAD_LDFLAGS} -o $@ ${PIANOBAR_OBJ} ${LIBPIANO_OBJ} \
-			${LIBWAITRESS_OBJ} ${LIBEZXML_OBJ}
+	${CC} ${CFLAGS} ${LDFLAGS} ${PIANOBAR_OBJ} ${LIBPIANO_OBJ} \
+			${LIBWAITRESS_OBJ} ${LIBEZXML_OBJ} -lao -lpthread -lm \
+			${LIBFAAD_LDFLAGS} ${LIBMAD_LDFLAGS} -o $@
 endif
 
 # build shared and static libpiano


### PR DESCRIPTION
I made a small patch to the Makefile that fixes the linking order so linking works properly when using the --as-needed flag. See the information under the "Importance of linking order" header close to the bottom of this [page](http://www.gentoo.org/proj/en/qa/asneeded.xml) if you want more information.

Thanks,
Tim
