### PR TITLE
Allow pianobar to be compiled on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DYNLINK:=0
 
 # Respect environment variables set by user; does not work with :=
 ifeq (${CFLAGS},)
-	CFLAGS=-O2 -DNDEBUG
+	CFLAGS=-O2 -DNDEBUG -I/usr/local/include -L/usr/local/lib
 endif
 ifeq (${CC},cc)
 	CC=c99

--- a/src/libezxml/ezxml.c
+++ b/src/libezxml/ezxml.c
@@ -22,7 +22,9 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#ifndef __FreeBSD__
 #define _BSD_SOURCE /* required by strdup() */
+#endif
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/libpiano/piano.c
+++ b/src/libpiano/piano.c
@@ -21,7 +21,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#ifndef __FreeBSD__
 #define _BSD_SOURCE /* required by strdup() */
+#endif
 
 #include <stdio.h>
 #include <string.h>

--- a/src/libpiano/xml.c
+++ b/src/libpiano/xml.c
@@ -21,7 +21,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#ifndef __FreeBSD__
 #define _BSD_SOURCE /* required by strdup() */
+#endif
 
 #include <stdio.h>
 #include <string.h>

--- a/src/libwaitress/waitress.c
+++ b/src/libwaitress/waitress.c
@@ -21,8 +21,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#ifndef __FreeBSD__
 #define _POSIX_C_SOURCE 1 /* required by getaddrinfo() */
 #define _BSD_SOURCE /* snprintf() */
+#endif
 
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/src/main.c
+++ b/src/main.c
@@ -21,8 +21,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#ifndef __FreeBSD__
 #define _POSIX_C_SOURCE 1 /* fileno() */
 #define _BSD_SOURCE /* strdup() */
+#endif
 
 /* system includes */
 #include <stdlib.h>

--- a/src/settings.c
+++ b/src/settings.c
@@ -23,8 +23,10 @@ THE SOFTWARE.
 
 /* application settings */
 
+#ifndef __FreeBSD__
 #define _POSIX_C_SOURCE 1 /* PATH_MAX */
 #define _BSD_SOURCE /* strdup() */
+#endif
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -21,8 +21,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
+#ifndef __FreeBSD__
 #define _POSIX_C_SOURCE 1 /* fileno() */
 #define _BSD_SOURCE /* setlinebuf() */
+#endif
 
 #include <termios.h>
 #include <stdio.h>

--- a/src/ui.c
+++ b/src/ui.c
@@ -23,8 +23,10 @@ THE SOFTWARE.
 
 /* everything that interacts with the user */
 
+#ifndef __FreeBSD__
 #define _POSIX_C_SOURCE 1 /* fileno() */
 #define _BSD_SOURCE /* strdup() */
+#endif
 
 #include <stdio.h>
 #include <stdarg.h>


### PR DESCRIPTION
Pianobar does not currently compile or operate correct on FreeBSD. These patches should be NOPs for the Linux community but allows the FreeBSD folk to use pianobar.
