### PR TITLE
Change from requesting username to requesting email

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -95,7 +95,7 @@ static void BarMainGetLoginCredentials (BarSettings_t *settings,
 		BarReadlineFds_t *input) {
 	if (settings->username == NULL) {
 		char nameBuf[100];
-		BarUiMsg (MSG_QUESTION, "Email: ");
+		BarUiMsg (settings, MSG_QUESTION, "Email: ");
 		BarReadlineStr (nameBuf, sizeof (nameBuf), input, BAR_RL_DEFAULT);
 		settings->username = strdup (nameBuf);
 	}


### PR DESCRIPTION
For the sake of clarity Pandora uses emails instead of usernames and this consistently seems to trip me up so I just changed the prompt.
