### PR TITLE
Add .PHONY to Makefile to avoid conflicts on case-insensitive file systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,3 +154,5 @@ install-libpiano:
 	install -m644 libpiano.a ${DESTDIR}/${LIBDIR}/
 	install -d ${DESTDIR}/${INCDIR}/
 	install -m644 src/libpiano/piano.h ${DESTDIR}/${INCDIR}/
+
+.PHONY: install test debug all


### PR DESCRIPTION
I ran into a problem where running "make install" would occasionally fail for me.  The command would report that everything was up to date.

The problem is my file system is case-insensitive.  There is an INSTALL file that interferes when running "make install".

The solution, as provided to me by dports on the #macports IRC channel, is to declare the "install" target in the Makefile as .PHONY so that make doesn't look for a file named install (or in my case, INSTALL).
