### PR TITLE
ctl shouldn't be in XDG_CONFIG_HOME

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -56,6 +56,8 @@ THE SOFTWARE.
 #include "ui_dispatch.h"
 #include "ui_readline.h"
 
+#define streq(a, b) (strcmp (a , b) == 0)
+
 /*	copy proxy settings to waitress handle
  */
 static void BarMainLoadProxy (const BarSettings_t *settings,
@@ -363,7 +365,12 @@ int main (int argc, char **argv) {
 	app.input.fds[0] = STDIN_FILENO;
 	FD_SET(app.input.fds[0], &app.input.set);
 
-	BarGetXdgConfigDir (PACKAGE "/ctl", ctlPath, sizeof (ctlPath));
+	if (streq (app.settings.ctlPath, "")) {
+		BarGetXdgConfigDir (PACKAGE "/ctl", ctlPath, sizeof (ctlPath));
+	} else {
+		snprintf (ctlPath, sizeof (ctlPath), "%s", app.settings.ctlPath);
+	}
+
 	/* open fifo read/write so it won't EOF if nobody writes to it */
 	assert (sizeof (app.input.fds) / sizeof (*app.input.fds) >= 2);
 	app.input.fds[1] = open (ctlPath, O_RDWR);

--- a/src/settings.c
+++ b/src/settings.c
@@ -88,6 +88,7 @@ void BarSettingsDestroy (BarSettings_t *settings) {
 	free (settings->eventCmd);
 	free (settings->loveIcon);
 	free (settings->banIcon);
+	free (settings->ctlPath);
 	free (settings->atIcon);
 	free (settings->npSongFormat);
 	free (settings->npStationFormat);
@@ -124,6 +125,7 @@ void BarSettingsRead (BarSettings_t *settings) {
 	settings->loveIcon = strdup (" <3");
 	settings->banIcon = strdup (" </3");
 	settings->atIcon = strdup (" @ ");
+	settings->ctlPath = strdup("");
 	settings->npSongFormat = strdup ("\"%t\" by \"%a\" on \"%l\"%r%@%s");
 	settings->npStationFormat = strdup ("Station \"%n\" (%i)");
 
@@ -220,6 +222,9 @@ void BarSettingsRead (BarSettings_t *settings) {
 		} else if (streq ("at_icon", key)) {
 			free (settings->atIcon);
 			settings->atIcon = strdup (val);
+		} else if (streq ("ctl_path", key)) {
+			free (settings->ctlPath);
+			settings->ctlPath = strdup(val);
 		} else if (streq ("volume", key)) {
 			settings->volume = atoi (val);
 		} else if (streq ("format_nowplaying_song", key)) {

--- a/src/settings.h
+++ b/src/settings.h
@@ -91,6 +91,7 @@ typedef struct {
 	char *eventCmd;
 	char *loveIcon;
 	char *banIcon;
+	char *ctlPath;
 	char *atIcon;
 	char *npSongFormat;
 	char *npStationFormat;


### PR DESCRIPTION
ctl isn't really a config file; it's a non-essential file. It would probably be better in XDG_RUNTIME_DIR, since it should only exist when pianobar is run and for there to be a configuration option to create the  fifo if it doesn't already exist. Unfortunately, the specification doesn't provide a default directory to look for, so the best choice, at the moment, is XDG_CACHE_HOME.
