### PR TITLE
Fix 'TLS read error' when using pianobar with some buggy(?) proxy

### DIFF
--- a/src/libwaitress/waitress.c
+++ b/src/libwaitress/waitress.c
@@ -535,10 +535,11 @@ static WaitressReturn_t WaitressGnutlsRead (void *data, char *buf,
 	WaitressHandle_t *waith = data;
 
 	ssize_t ret = gnutls_record_recv (waith->request.tlsSession, buf, size);
-	if (ret < 0) {
+	if (ret < 0 && ret != -110) {
 		return WAITRESS_RET_TLS_READ_ERR;
 	} else {
-		*retSize = ret;
+		if(ret == -110)*retSize = 0;
+		else *retSize = ret;
 	}
 	return waith->request.readWriteRet;
 }


### PR DESCRIPTION
If the proxy close the connection to server too early, gnutls_record_recv() will result in a GNUTLS_E_PREMATURE_TERMINATION thus pianobar exit with 'TLS read error', regardless of the fact that all the data has been received.
This commit is a workaround for this situation.
