### PR TITLE
fixes #204 issue with login claiming system time is out of sync

### DIFF
--- a/src/libpiano/piano.c
+++ b/src/libpiano/piano.c
@@ -236,8 +236,7 @@ PianoReturn_t PianoRequest (PianoHandle_t *ph, PianoRequest_t *req,
 	assert (req != NULL);
 
 	req->type = type;
-	/* no tls by default */
-	req->secure = false;
+	req->secure = true;
 
 	switch (req->type) {
 		case PIANO_REQUEST_LOGIN: {
@@ -310,6 +309,9 @@ PianoReturn_t PianoRequest (PianoHandle_t *ph, PianoRequest_t *req,
 			break;
 
 		case PIANO_REQUEST_GET_PLAYLIST: {
+			/* disable tls for fetching playlists */
+			req->secure = false;
+
 			/* get playlist for specified station */
 			PianoRequestDataGetPlaylist_t *reqData = req->data;
 


### PR DESCRIPTION
I've tested a bunch of the other actions (though not exhaustively) and seems like things are properly functional after enabling tls by default and only disabling it for playlist fetch.
