### PR TITLE
Makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifeq (${CFLAGS},)
 	CFLAGS=-O2 -DNDEBUG
 endif
 ifeq (${CC},cc)
-	CC=c99
+	CFLAGS+=-std=c99
 endif
 
 PIANOBAR_DIR=src


### PR DESCRIPTION
Should fix #247 and #245.

Note that the fix for 247 just uses the LIBJSONC_CFLAGS, in stead of making a separate variable to query using pkg-config --cflags-only-I json because at this point in time, the cflags for libjsonc are only -I

Also, the fix for #245 makes sense. There should be more aliases of cc, rather than aliases of c99.

They're both 1 line changes, so a pull request probably isn't necessary. I'm just kinda playing with github.
