### PR TITLE
libjson not linked correctly for libpiano

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BINDIR:=${PREFIX}/bin
 LIBDIR:=${PREFIX}/lib
 INCDIR:=${PREFIX}/include
 MANDIR:=${PREFIX}/share/man
-DYNLINK:=1
+DYNLINK:=0
 
 # Respect environment variables set by user; does not work with :=
 ifeq (${CFLAGS},)


### PR DESCRIPTION
When building libpiano, the json library isn't being liked correctly. This is necessary to correctly use the library independently. For example importing the original library into python via ctypes results in the following error:

`/usr/local/lib/libpiano.so.0.0.0: undefined symbol: json_tokener_parse`
