### PR TITLE
SIGRTMIN is not defined on OS X, using SIGUSR1 in it's place

### DIFF
--- a/src/player.h
+++ b/src/player.h
@@ -45,6 +45,12 @@ THE SOFTWARE.
 
 #include "settings.h"
 
+#ifndef SIGRTMIN
+#ifdef SIGUSR1
+#define SIGRTMIN SIGUSR1
+#endif /* SIGUSR1 */
+#endif /* SIGRTMIN */
+
 #define BAR_PLAYER_MS_TO_S_FACTOR 1000
 #define BAR_PLAYER_BUFSIZE (WAITRESS_BUFFER_SIZE*2)
 #define BAR_PLAYER_SIGSTOP SIGRTMIN


### PR DESCRIPTION
For Issue #256

I don't know an awful lot about C. I looked up some info online about SIGRTMIN and what people use on OS X since it's not defined and SIGUSR1 was recommend. I was able to compile and can confirm that play and pause work properly on OS X 10.6.8.
