### PR TITLE
Keybinding Issue in config file

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -205,9 +205,6 @@ void BarSettingsRead (BarSettings_t *settings) {
 			free (settings->inkey);
 			settings->inkey = strdup (val);
 		} else if (memcmp ("act_", key, 4) == 0) {
-		} else if (memcmp ("act_", key, 4) == 0) {
-		} else if (memcmp ("act_", key, 4) == 0) {
-		} else if (memcmp ("act_", key, 4) == 0) {
 			size_t i;
 			/* keyboard shortcuts */
 			for (i = 0; i < BAR_KS_COUNT; i++) {


### PR DESCRIPTION
I've been having trouble with the custom keybindings in the config file as I'd like to disable a large majority of them so I can't do any harm with accidental key presses. It appears the problem was that you simply duplicated a few lines in src/settings.c.
Cheers!
