### PR TITLE
Add config option to start paused

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -319,6 +319,12 @@ static void BarMainLoop (BarApp_t *app) {
 				app->player.mode < PLAYER_FINISHED_PLAYBACK) {
 			BarMainPrintTime (app);
 		}
+		
+		/* song is about to start, pause it */
+		if (app->settings.startPaused==true) {
+			pthread_mutex_trylock (&app->player.pauseMutex);
+			app->settings.startPaused=false;
+		}
 	}
 
 	if (app->player.mode != PLAYER_FREED) {

--- a/src/settings.c
+++ b/src/settings.c
@@ -122,6 +122,7 @@ void BarSettingsRead (BarSettings_t *settings) {
 
 	/* apply defaults */
 	settings->audioQuality = PIANO_AQ_HIGH;
+	settings->startPaused = false;
 	settings->autoselect = true;
 	settings->history = 5;
 	settings->volume = 0;
@@ -269,6 +270,8 @@ void BarSettingsRead (BarSettings_t *settings) {
 		} else if (streq ("fifo", key)) {
 			free (settings->fifo);
 			settings->fifo = strdup (val);
+		} else if (streq ("startPaused", key)) {
+			settings->startPaused = atoi (val);
 		} else if (streq ("autoselect", key)) {
 			settings->autoselect = atoi (val);
 		} else if (streq ("tls_fingerprint", key)) {

--- a/src/settings.h
+++ b/src/settings.h
@@ -81,6 +81,7 @@ typedef struct {
 } BarMsgFormatStr_t;
 
 typedef struct {
+	bool startPaused;
 	bool autoselect;
 	unsigned int history;
 	int volume;


### PR DESCRIPTION
Just wrote this up for myself, I figured you might also want to implement a similar feature.
Simply add "startPaused = 0" to pianobar/config and it will start paused (useful for run-on-startup scripts).
