### PR TITLE
headless_pianobar

### DIFF
--- a/contrib/headless_pianobar
+++ b/contrib/headless_pianobar
@@ -69,8 +69,8 @@ OUTPUT_LINES="30"
 if [ ! -p $HOME/.config/pianobar/ctl ]
 then
 	echo "pianobar ctl fifo not present at $HOME/.config/pianobar/ctl"
-	echo "Create? (y/N)"
-	gead YN
+	echo -n "Create? (y/N) "
+	read YN
 	if [ "$YN" = "y" ] || [ "$YN" = "yes" ] || [ "$YN" = "Y" ] || [ "$YN" = "YES" ]
 	then
 		mkdir -p $HOME/.config/pianobar/
@@ -147,6 +147,7 @@ RUNNINGPID=$!
 # simply gets an empty variable back.  Detect this situation and pass a newline
 # along to pianobar.  Otherwise, send the character read from input to
 # pianobar.
+IFS=""
 while /bin/true
 do
 	read -n1 -s INPUT


### PR DESCRIPTION
In addition to personal interest in running pianobar headlessly, as well as
interest in it from other people I know personally, there has been at
least one feature request through github to run pianobar headlessly:
    https://github.com/PromyLOPh/pianobar/issues/39

The response to the feature request says "Feel free to send patches",
and so I figured I'd do so.

headless_pianobar is a relatively simple shell script wrapper for
pianobar which will allow it to function headlessly.  I had hoped to
make it as portable as possible, but ran into limitations with getting
input one character at a time with the bourne shell, and thus fell back
to using bash.

If any issues are found which would limit it from being added upstream,
let me know and I will do what I can to remedy them.
