### PR TITLE
json-c-0.11 renamed the pkgconfig file to json-c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,8 @@ LIBGNUTLS_LDFLAGS=$(shell pkg-config --libs gnutls)
 LIBGCRYPT_CFLAGS=
 LIBGCRYPT_LDFLAGS=-lgcrypt
 
-LIBJSONC_CFLAGS=$(shell pkg-config --cflags json)
-LIBJSONC_LDFLAGS=$(shell pkg-config --libs json)
+LIBJSONC_CFLAGS=$(shell pkg-config --cflags json-c)
+LIBJSONC_LDFLAGS=$(shell pkg-config --libs json-c)
 
 # build pianobar
 ifeq (${DYNLINK},1)


### PR DESCRIPTION
json-c-0.11 renamed the pkgconfig file to json-c
https://github.com/json-c/json-c/blob/master/ChangeLog

Signed-off-by: Markos Chandras hwoarang@gentoo.org
