### PR TITLE
Send the audioUrl to the event_command program

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -744,6 +744,7 @@ void BarUiStartEventCmd (const BarSettings_t *settings, const char *type,
 				"title=%s\n"
 				"album=%s\n"
 				"coverArt=%s\n"
+				"audioUrl=%s\n"
 				"stationName=%s\n"
 				"songStationName=%s\n"
 				"pRet=%i\n"
@@ -758,6 +759,7 @@ void BarUiStartEventCmd (const BarSettings_t *settings, const char *type,
 				curSong == NULL ? "" : curSong->title,
 				curSong == NULL ? "" : curSong->album,
 				curSong == NULL ? "" : curSong->coverArt,
+				curSong == NULL ? "" : curSong->audioUrl,
 				curStation == NULL ? "" : curStation->name,
 				songStation == NULL ? "" : songStation->name,
 				pRet,


### PR DESCRIPTION
This is useful to making pianobar simply a music fetcher, so you can stream the music in VLC. 
