### PR TITLE
Changed headless_pianobar to support command-line arguments and reading the pianobar config file

### DIFF
--- a/contrib/headless_pianobar
+++ b/contrib/headless_pianobar
@@ -56,49 +56,66 @@
 # techniques and currently requires bash.
 
 
-# This script regularly checks whether or not pianobar is running in the
-# background in order to detect when it closes.  This variable sets how long of
-# a delay there will be between checks (in seconds).
+# Set default config options, as defined in the pianobar man page. Only set for variables actually used.
+# They can all be overridden by the main pianobar config file.
+# headless_pianobar options:
+# check_period: sets how frequently the script checks if pianobar is running
+# output_lines: sets how many lines of pianobar output to print when reconnecting
 CHECK_PERIOD=${CHECK_PERIOD:-"1"}
-
-# This variable will set how many lines of pianobar's output to print when
-# re-connecting to pianobar.
 OUTPUT_LINES=${OUTPUT_LINES:-"30"}
+ACT_SONGPLAY=P
+ACT_SONGPAUSETOGGLE=p
+ACT_SONGPAUSETOGGLE2=' ' # space
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
+FIFO=$XDG_CONFIG_HOME/pianobar/ctl
+OUT=$XDG_CONFIG_HOME/pianobar/out
+CONFIG=$XDG_CONFIG_HOME/pianobar/config
 
-# Ensure the ctrl fifo exists.
-if [ ! -p $HOME/.config/pianobar/ctl ]
-then
-	echo "pianobar ctl fifo not present at $HOME/.config/pianobar/ctl"
-	echo -n "Create? (y/N) "
-	read YN
-	if [ "$YN" = "y" ] || [ "$YN" = "yes" ] || [ "$YN" = "Y" ] || [ "$YN" = "YES" ]
-	then
-		mkdir -p $HOME/.config/pianobar/
-		mkfifo  $HOME/.config/pianobar/ctl
-		if [ ! -p $HOME/.config/pianobar/ctl ]
-		then
-			echo "Failed to create fifo, aborting"
-			exit 1
-		fi
-	else
-		exit 1
-	fi
-fi
+
+# Load the pianobar config file as bash variables
+# also strip password info for security reasons
+# ex: act_upcoming becomes ACT_UPCOMING
+# ex: user becomes PIANOBAR_USER (in order to avoid conflicts with the user environment variable)
+load_config(){
+        if [[ -r $CONFIG ]]
+        then
+                source <(sed -n \
+                        -e 's/password.*//' \
+                        -e 's/user/pianobar_user/' \
+                        -e 's/\([0-9A-Za-z_]*\) = \(.*\)/\U\1\E="\2"/p' < $CONFIG)
+        else
+                echo "Couldn't load config file $CONFIG, using defaults"
+                false
+        fi
+}
+
+is_running(){
+        ps -u $(id -u) -o comm | grep -q "^pianobar$"
+}
 
 # Launch pianobar if it is not already running.
-if ! ps -u $(id -u) -o comm | grep -q "^pianobar$"
-then
-	echo "pianobar not running, launching pianobar"
-	nohup pianobar &>$HOME/.config/pianobar/out &disown
-	sleep 1
-fi
+launch(){
+        if ! is_running
+        then
+                ensure_fifo true
+                echo "Pianobar not running, launching Pianobar"
+                nohup pianobar &>$OUT &disown
+                sleep 1
+        else
+                ensure_fifo
+        fi
+}
 
-# Sanity check: ensure pianobar's output can be read.
-if [ ! -f $HOME/.config/pianobar/out ]
-then
-	echo "pianobar does not seem to be outputting to $HOME/.config/pianobar/out, try killing it and starting $0 again"
-	exit 2
-fi
+# Check on a regular basis that pianobar is still running.
+# If pianobar stops running, stop this script as well.
+running(){
+        while is_running
+        do
+        	sleep $CHECK_PERIOD
+        done
+        echo "Pianobar died, quitting"
+        quit
+}
 
 # Function to cleanly quit.  Ensures that the two backgrounded processes (the
 # output, tail, and the check, running()) both exit along with the parent (this
@@ -120,44 +137,105 @@ quit(){
 	exit 0
 }
 
-# Check on a regular basis that pianobar is still running.
-# If pianobar stops running, stop this script as well.
-running(){
-	while ps -u $(id -u) -o comm | grep -q "^pianobar$"
-	do
-		sleep $CHECK_PERIOD
-	done
-	echo "pianobar died, quitting"
-	quit
-}
-
-# Ensure quit() is called to clean up when exiting
-trap quit HUP INT TERM
-
 # Print pianobar's output.
-tail -n$OUTPUT_LINES -f $HOME/.config/pianobar/out &
-TAILPID=$!
+output(){
+        # Sanity check: ensure pianobar's output can be read.
+        if [ ! -f $OUT ]
+        then
+                echo "pianobar does not seem to be outputting to $OUT, try killing it and starting $0 again"
+                exit 2
+        fi
 
-# Run running() in the background to detect when pianobar closes.
-running &
-RUNNINGPID=$!
+        tail -n$OUTPUT_LINES -f $OUT &
+        TAILPID=$!
+}
 
 # Get input from user, character by character, and feed it to pianobar's ctl
 # fifo.  Note that no newline character is given with `read`.  Rather, one
 # simply gets an empty variable back.  Detect this situation and pass a newline
 # along to pianobar.  Otherwise, send the character read from input to
-# pianobar.
-IFS=""
-while /bin/true
-do
-	read -n1 -s INPUT
-        if [[ $? == "1" || "$INPUT" == $'\004' ]]
+# pianobar. If ^D or EOF is given, quit
+input(){
+        IFS=""
+        while /bin/true
+        do
+                read -n1 -s INPUT
+                if [[ $? == "1" || "$INPUT" == $'\004' ]]
+                then
+                        quit
+                elif [ "$INPUT" == "" ]
+                then
+                        send_input "\n"
+                else
+                        send_input "$INPUT"
+                fi
+        done
+}
+
+# send the first argument to the control fifo
+send_input(){
+        echo -ne "$1" > $FIFO
+}
+
+# Ensure the ctrl fifo exists. Arg1: create if it doesn't exist
+ensure_fifo(){
+        if [ ! -p $FIFO ]
         then
-                quit
-	elif [ "$INPUT" == "" ]
-	then
-		echo "" > $HOME/.config/pianobar/ctl
-	else
-		echo -n $INPUT > $HOME/.config/pianobar/ctl
-	fi
-done
+                if [[ $1 ]]
+                then
+                        echo "Pianobar ctl fifo not present at $FIFO, creating"
+                        mkfifo $FIFO
+                        if [ ! -p $FIFO ]
+                        then
+                                echo "Failed to create fifo, aborting"
+                                exit 1
+                        fi
+                else
+                        echo "Pianobar ctl fifo not present at $FIFO, aborting"
+                        exit 1
+                fi
+        fi
+}
+
+# Ensure quit() is called to clean up when exiting
+trap quit HUP INT TERM
+
+mkdir -p $XDG_CONFIG_HOME/pianobar
+
+# load the main pianobar config file
+# Don't use $XDG_CONFIG_HOME or $HOME after this because it may have changed if set in the config file.
+load_config
+
+# if no arguments, launch pianobar if not running, then connect to the pianobar ui
+if [[ $# == 0 ]]
+then
+        launch
+
+        # Run running() in the background to detect when pianobar closes.
+        running &
+        RUNNINGPID=$!
+
+        output
+
+        input
+else
+        if ! is_running
+        then
+# if there are arguments, and pianobar is not running, start pianobar if it makes sense to
+                case $1 in
+                        $ACT_SONGPLAY | $ACT_SONGPAUSETOGGLE | $ACT_SONGPAUSETOGGLE2)
+                                launch
+                                shift ;;
+                        *)
+                                echo "Pianobar not running, nothing executed"
+                                exit 0
+                                ;;
+                esac
+        fi
+# if there are arguments and pianobar is running, send arguments to pianobar, then exit
+        ensure_fifo
+        while [[ $# > 0 ]]; do
+                send_input "$1"
+                shift
+        done
+fi


### PR DESCRIPTION
The script supports command-line arguments to control pianobar. ex: "headless_pianobar p" starts pianobar (assuming default key bindings). The idea is that someone could just set a bunch of key bindings. It will also parse the pianobar config file so that it can intelligently read the keys.

I know last time you said that it might make sense to keep development in another project, and I am ok with doing that, but I, personally, would rather keep it here because it should make it into my distro's official packages, and it really is the same script. I do not anticipate making more changes to it, unless if someone uncovers a bug, or you change how pianobar functions. The only other change I see being made is to make it more portable, as the original author pointed out, but if it happens, I probably won't do it.
