### PR TITLE
Port Makefile to OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ ifeq (${CC},cc)
 		CC=gcc -std=c99
 	else ifeq (${OS},FreeBSD)
 		CC=cc -std=c99
+	else ifeq (${OS},OpenBSD)
+		CC=cc -std=c99
 	else
 		CC=c99
 	endif


### PR DESCRIPTION
This really just tells the makefile how to call the compiler
on OpenBSD. You'll also want the following packages:
  json
  libmad
  libao
  faad
  gnutls
