### PR TITLE
small fix for headless_pianobar: $0 refers to func name when inside a func, not the script.

### DIFF
--- a/contrib/headless_pianobar
+++ b/contrib/headless_pianobar
@@ -70,6 +70,7 @@ XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 FIFO=$XDG_CONFIG_HOME/pianobar/ctl
 OUT=$XDG_CONFIG_HOME/pianobar/out
 CONFIG=$XDG_CONFIG_HOME/pianobar/config
+SELF=$0
 
 
 # Load the pianobar config file as bash variables
@@ -142,7 +143,7 @@ output(){
         # Sanity check: ensure pianobar's output can be read.
         if [ ! -f $OUT ]
         then
-                echo "pianobar does not seem to be outputting to $OUT, try killing it and starting $0 again"
+                echo "pianobar does not seem to be outputting to $OUT, try killing it and starting $SELF again"
                 exit 2
         fi
 


### PR DESCRIPTION
$0 is the name of the script and $1,$2,..$x are command line args, unless you are inside a function.  Inside a function, $0 is the name of the function and $1,$2,..$x are args passed to the function.  So referencing $0 from w/in a function will give you the name of the function, not the name of the script as desired.  Easy fix tho.
