### PR TITLE
pulls down the prescribed audio ads, and allows the configuration of eit...

### DIFF
--- a/src/libpiano/piano.h
+++ b/src/libpiano/piano.h
@@ -94,6 +94,7 @@ typedef struct PianoSong {
 	char *feedbackId;
 	char *detailUrl;
 	char *trackToken;
+	char *adToken;
 	float fileGain;
 	PianoSongRating_t rating;
 	PianoAudioFormat_t audioFormat;
@@ -169,6 +170,8 @@ typedef enum {
 	PIANO_REQUEST_GET_STATION_INFO = 20,
 	PIANO_REQUEST_DELETE_FEEDBACK = 21,
 	PIANO_REQUEST_DELETE_SEED = 22,
+	PIANO_REQUEST_GET_AD_METADATA = 23,
+	PIANO_REQUEST_REGISTER_AD = 24,
 } PianoRequestType_t;
 
 typedef struct PianoRequest {
@@ -243,6 +246,22 @@ typedef struct {
 	PianoArtist_t *artist;
 	PianoStation_t *station;
 } PianoRequestDataDeleteSeed_t;
+
+typedef struct {
+	char *token;
+	char **retToken;
+	char *audioUrl;
+	float fileGain;
+	PianoAudioFormat_t audioFormat;
+	PianoAudioQuality_t quality;
+	size_t retTokenCount;
+} PianoRequestDataGetAdMetadata_t;
+
+typedef struct {
+	char **token;
+	size_t tokenCount;
+	PianoStation_t *station;
+} PianoRequestDataRegisterAd_t;
 
 /* pandora error code offset */
 #define PIANO_RET_OFFSET 1024

--- a/src/libpiano/request.c
+++ b/src/libpiano/request.c
@@ -80,6 +80,10 @@ PianoReturn_t PianoRequest (PianoHandle_t *ph, PianoRequest_t *req,
 							json_object_new_string ("5"));
 					json_object_object_add (j, "includeUrls",
 							json_object_new_boolean (true));
+					json_object_object_add (j, "returnDeviceType",
+							json_object_new_boolean (true));
+					json_object_object_add (j, "returnUpdatePromptVersions",
+							json_object_new_boolean (true));
 					snprintf (req->urlPath, sizeof (req->urlPath),
 							PIANO_RPC_PATH "method=auth.partnerLogin");
 					break;
@@ -133,6 +137,22 @@ PianoReturn_t PianoRequest (PianoHandle_t *ph, PianoRequest_t *req,
 
 			json_object_object_add (j, "stationToken",
 					json_object_new_string (reqData->station->id));
+			json_object_object_add (j, "includeTrackLength",
+					json_object_new_boolean (true));
+			json_object_object_add (j, "includeAudioToken",
+					json_object_new_boolean (true));
+			json_object_object_add (j, "xplatformAdCapable",
+					json_object_new_boolean (true));
+			json_object_object_add (j, "includeAudioReceiptUrl",
+					json_object_new_boolean (true));
+			json_object_object_add (j, "includeCompetitiveSepIndicator",
+					json_object_new_boolean (true));
+			json_object_object_add (j, "includeCompletePlaylist",
+					json_object_new_boolean (true));
+			json_object_object_add (j, "includeTrackOptions",
+					json_object_new_boolean (true));
+			json_object_object_add (j, "audioAdPodCapable",
+					json_object_new_boolean (true));
 
 			method = "station.getPlaylist";
 			break;
@@ -395,6 +415,49 @@ PianoReturn_t PianoRequest (PianoHandle_t *ph, PianoRequest_t *req,
 					json_object_new_string (seedId));
 
 			method = "station.deleteMusic";
+			break;
+		}
+
+		case PIANO_REQUEST_GET_AD_METADATA: {
+			PianoRequestDataGetAdMetadata_t *reqData = req->data;
+
+			assert (reqData != NULL);
+			assert (reqData->token != NULL);
+
+			json_object_object_add (j, "adToken",
+					json_object_new_string (reqData->token));
+			json_object_object_add (j, "returnAdTrackingTokens",
+							json_object_new_boolean (true));
+			json_object_object_add (j, "supportAudioAds",
+							json_object_new_boolean (true));
+			json_object_object_add (j, "includeBannerAd",
+							json_object_new_boolean (true));
+			json_object_object_add (j, "includeListeningHours",
+							json_object_new_boolean (true));
+
+			method = "ad.getAdMetadata";
+			break;
+		}
+
+		case PIANO_REQUEST_REGISTER_AD: {
+			PianoRequestDataRegisterAd_t *reqData = req->data;
+
+			assert (reqData != NULL);
+			assert (reqData->token != NULL);
+			assert (reqData->tokenCount > 0);
+			assert (reqData->station != NULL);
+			assert (reqData->station->id != NULL);
+
+			json_object_object_add (j, "stationId",
+					json_object_new_string (reqData->station->id));
+			json_object * const token = json_object_new_array ();
+			for (size_t i = 0; i < reqData->tokenCount; i++) {
+				json_object_array_add (token,
+						json_object_new_string (reqData->token[i]));
+			}
+			json_object_object_add (j, "adTrackingTokens", token);
+
+			method = "ad.registerAd";
 			break;
 		}
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -123,6 +123,7 @@ void BarSettingsRead (BarSettings_t *settings) {
 	/* apply defaults */
 	settings->audioQuality = PIANO_AQ_HIGH;
 	settings->autoselect = true;
+	settings->silenceAds = true;
 	settings->history = 5;
 	settings->volume = 0;
 	settings->maxPlayerErrors = 5;
@@ -286,6 +287,8 @@ void BarSettingsRead (BarSettings_t *settings) {
 				settings->fifo = strdup (val);
 			} else if (streq ("autoselect", key)) {
 				settings->autoselect = atoi (val);
+			} else if (streq ("silence_ads", key)) {
+				settings->silenceAds = atoi (val);
 			} else if (streq ("tls_fingerprint", key)) {
 				/* expects 40 byte hex-encoded sha1 */
 				if (strlen (val) == 40) {

--- a/src/settings.h
+++ b/src/settings.h
@@ -106,6 +106,7 @@ typedef struct {
 	char tlsFingerprint[20];
 	char keys[BAR_KS_COUNT];
 	BarMsgFormatStr_t msgFormat[MSG_COUNT];
+	bool silenceAds;
 } BarSettings_t;
 
 #include <piano.h>


### PR DESCRIPTION
...her playing them silently or at normal volume. This keeps the playback timeline accurate, so should prevent appearing as an abnormal client. The default is to silence the ads.

Caution: complete newbie to git/github, this is my first commit ever.
