### PR TITLE
Fix traffic to allow proxying.

### DIFF
--- a/src/libwaitress/waitress.c
+++ b/src/libwaitress/waitress.c
@@ -914,21 +914,18 @@ static WaitressReturn_t WaitressSendRequest (WaitressHandle_t *waith) {
 	/* send request */
 	if (WaitressProxyEnabled (waith) && !waith->url.tls) {
 		snprintf (buf, WAITRESS_BUFFER_SIZE,
-			"%s http://%s:%s/%s HTTP/" WAITRESS_HTTP_VERSION "\r\n",
+			"%s http://%s:%s/%s HTTP/" WAITRESS_HTTP_VERSION "\r\n"
+			"Host: %s\r\nUser-Agent: " PACKAGE "\r\nConnection: Close\r\n",
 			(waith->method == WAITRESS_METHOD_GET ? "GET" : "POST"),
 			waith->url.host,
-			WaitressDefaultPort (&waith->url), path);
+			WaitressDefaultPort (&waith->url), path, waith->url.host);
 	} else {
 		snprintf (buf, WAITRESS_BUFFER_SIZE,
-			"%s /%s HTTP/" WAITRESS_HTTP_VERSION "\r\n",
-			(waith->method == WAITRESS_METHOD_GET ? "GET" : "POST"),
-			path);
-	}
-	WRITE_RET (buf, strlen (buf));
-
-	snprintf (buf, WAITRESS_BUFFER_SIZE,
+			"%s /%s HTTP/" WAITRESS_HTTP_VERSION "\r\n"
 			"Host: %s\r\nUser-Agent: " PACKAGE "\r\nConnection: Close\r\n",
-			waith->url.host);
+			(waith->method == WAITRESS_METHOD_GET ? "GET" : "POST"),
+			path, waith->url.host);
+	}
 	WRITE_RET (buf, strlen (buf));
 
 	if (waith->method == WAITRESS_METHOD_POST && waith->postData != NULL) {


### PR DESCRIPTION
When proxying pianobar the TLS connection doesn't specify a server_name. This means one IP can't be used to proxy multiple services. Instead include the server_name extension.

Also sniproxy had issues with fragmented packets. They've since been fixed but to me it still makes sense to include the Host header in the first packet sent.

I've tested this change locally for the last couple months with no issues.
