### PR TITLE
avfilter_copy_buf_props() is declared in libavfilter/avcodec.h on my system (ffmpeg 1.2), include it.

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -36,6 +36,7 @@ THE SOFTWARE.
 #include <libavformat/avformat.h>
 #include <libavutil/avutil.h>
 #include <libavfilter/avfilter.h>
+#include <libavfilter/avcodec.h>
 #include <libavfilter/avfiltergraph.h>
 #include <libavfilter/buffersink.h>
 #include <libavfilter/buffersrc.h>


### PR DESCRIPTION
Not sure if other LIBAV implementations provide this header, if so it will need to be guarded by a conditional.
