### PR TITLE
Fix Makefile to allow setting LIBAV from shell.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MANDIR:=${PREFIX}/share/man
 DYNLINK:=0
 # choose your libav implementation.
 # supported: ffmpeg2.2, ffmpeg2.1, ffmpeg1.2, libav10, libav9
-LIBAV:=undefined
+LIBAV?=undefined
 
 # Respect environment variables set by user; does not work with :=
 ifeq (${CFLAGS},)


### PR DESCRIPTION
Use Make's ?= assignment to not override a shell-passed LIBAV. This allows compiling with, for example, `LIBAV=ffmpeg2.2 make`.
