### PR TITLE
Print error message when proxy URL format is incorrect

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -69,9 +69,17 @@ static void BarMainLoadProxy (const BarSettings_t *settings,
 	 * firewalled fellows) */
 	if (settings->controlProxy != NULL) {
 		/* control proxy overrides global proxy */
-		WaitressSetProxy (waith, settings->controlProxy);
+		if (!WaitressSetProxy (waith, settings->controlProxy)) {
+			/* if setting proxy fails, url is invalid */
+			BarUiMsg(settings, MSG_ERR, "Control proxy (%s) is invalid!\n",
+					 settings->controlProxy);
+		}
 	} else if (settings->proxy != NULL && strlen (settings->proxy) > 0) {
-		WaitressSetProxy (waith, settings->proxy);
+		if (!WaitressSetProxy (waith, settings->proxy)) {
+			/* if setting proxy fails, url is invalid */
+			BarUiMsg(settings, MSG_ERR, "Proxy (%s) is invalid!\n",
+					 settings->proxy);
+		}
 	}
 }
 


### PR DESCRIPTION
WaitressSplitUrl doesn't accept protocols other than http. In particular, this means if the user has a proxy (either control_proxy or proxy) set up that uses HTTPS as the protocol, setting the waitress proxy silently fails and the proxy isn't used. This prints an error message when the url can't be parsed - it has to be generic since WaitressSplitUrl only returns a boolean false when something goes wrong rather than a specific error code.
