### PR TITLE
Handle connect failures in WaitressConnect

### DIFF
--- a/src/libwaitress/waitress.c
+++ b/src/libwaitress/waitress.c
@@ -808,7 +808,14 @@ static WaitressReturn_t WaitressConnect (WaitressHandle_t *waith) {
 			fcntl (sock, F_SETFL, O_NONBLOCK);
 
 			/* non-blocking connect will return immediately */
-			connect (sock, gacurr->ai_addr, gacurr->ai_addrlen);
+			if (connect (sock, gacurr->ai_addr, gacurr->ai_addrlen) == -1) {
+				// Error if not in-progress or immediate success
+				if (errno != EINPROGRESS) {
+					// Close socket and try alternatives
+					close (sock);
+					continue;
+				}
+			}
 
 			pollres = WaitressPollLoop (sock, POLLOUT, waith->timeout);
 			if (pollres == 0) {


### PR DESCRIPTION
Some systems would not play any streams - login & station lists OK. Error was "Unable to open audio file", Failing systems had a disabled IPv6 interface. getaddrinfo was returning IPv6 addresses which failed the connect - not the socket() call.