### PR TITLE
Add ability to toggle the explicit content filter

### DIFF
--- a/contrib/pianobar.1
+++ b/contrib/pianobar.1
@@ -178,6 +178,10 @@ Replacement for %@ in station format string. It's " @ " by default.
 Select audio quality.
 
 .TP
+.B act_explicitcontentfiltertoggle = f
+Toggles the explicit content filter.
+
+.TP
 .B autoselect = {1,0}
 Auto-select last remaining item of filtered list. Currently enabled for station
 selection only.
@@ -386,7 +390,7 @@ stationaddgenre, stationaddmusic, stationaddshared, stationcreate,
 stationdelete, stationdeleteartistseed, stationdeletefeedback,
 stationdeletesongseed, stationfetchinfo, stationfetchplaylist,
 stationfetchgenre stationquickmixtoggle, stationrename, userlogin,
-usergetstations
+usergetstations, getusersettings, changeexplicitcontentsetting
 
 An example script can be found in the contrib/ directory of
 .B pianobar's

--- a/src/libpiano/piano.h
+++ b/src/libpiano/piano.h
@@ -170,6 +170,8 @@ typedef enum {
 	PIANO_REQUEST_GET_STATION_INFO = 20,
 	PIANO_REQUEST_DELETE_FEEDBACK = 21,
 	PIANO_REQUEST_DELETE_SEED = 22,
+	PIANO_REQUEST_GET_SETTINGS = 23,
+	PIANO_REQUEST_CHANGE_EXPLICIT_CONTENT_SETTING = 24
 } PianoRequestType_t;
 
 typedef struct PianoRequest {
@@ -244,6 +246,11 @@ typedef struct {
 	PianoArtist_t *artist;
 	PianoStation_t *station;
 } PianoRequestDataDeleteSeed_t;
+
+typedef struct {
+	char isExplicitContentFilterEnabled;
+	char isExplicitContentFilterPINProtected;
+} PianoRequestDataGetExplicitContentFilterInfo_t;
 
 /* pandora error code offset */
 #define PIANO_RET_OFFSET 1024

--- a/src/libpiano/request.c
+++ b/src/libpiano/request.c
@@ -426,6 +426,24 @@ PianoReturn_t PianoRequest (PianoHandle_t *ph, PianoRequest_t *req,
 			goto cleanup;
 			break;
 		}
+
+		case PIANO_REQUEST_GET_SETTINGS: {
+			/* receive user settings */
+			method = "user.getSettings";
+			break;
+		}
+
+		case PIANO_REQUEST_CHANGE_EXPLICIT_CONTENT_SETTING: {
+			PianoRequestDataGetExplicitContentFilterInfo_t *reqData = req->data;
+
+			assert (reqData != NULL);
+
+			json_object_object_add (j, "isExplicitContentFilterEnabled",
+					json_object_new_boolean (reqData->isExplicitContentFilterEnabled));
+
+			method = "user.setExplicitContentFilter";
+			break;
+		}
 	}
 
 	/* standard parameter */

--- a/src/libpiano/response.c
+++ b/src/libpiano/response.c
@@ -601,6 +601,17 @@ PianoReturn_t PianoResponse (PianoHandle_t *ph, PianoRequest_t *req) {
 			}
 			break;
 		}
+		
+		case PIANO_REQUEST_GET_SETTINGS: {
+			PianoRequestDataGetExplicitContentFilterInfo_t *reqData = req->data;
+
+			assert (reqData != NULL);
+
+			reqData->isExplicitContentFilterEnabled = json_object_get_boolean (json_object_object_get (result, "isExplicitContentFilterEnabled"));
+			reqData->isExplicitContentFilterPINProtected = json_object_get_boolean (json_object_object_get (result, "isExplicitContentFilterPINProtected"));
+
+			break;
+		}
 	}
 
 cleanup:

--- a/src/settings.h
+++ b/src/settings.h
@@ -59,8 +59,9 @@ typedef enum {
 	BAR_KS_PLAY = 26,
 	BAR_KS_PAUSE = 27,
 	BAR_KS_VOLRESET = 28,
+	BAR_KS_TOGGLEEXPLICITCONTENT = 29,
 	/* insert new shortcuts _before_ this element and increase its value */
-	BAR_KS_COUNT = 29,
+	BAR_KS_COUNT = 30,
 } BarKeyShortcutId_t;
 
 #define BAR_KS_DISABLED '\x00'

--- a/src/ui_act.h
+++ b/src/ui_act.h
@@ -61,5 +61,6 @@ BarUiActCallback(BarUiActVolDown);
 BarUiActCallback(BarUiActVolUp);
 BarUiActCallback(BarUiActManageStation);
 BarUiActCallback(BarUiActVolReset);
+BarUiActCallback(BarUiActToggleExplicitContentFilter);
 
 #endif /* SRC_UI_ACT_H_1FEFTC06 */

--- a/src/ui_dispatch.h
+++ b/src/ui_dispatch.h
@@ -103,6 +103,8 @@ static const BarUiDispatchAction_t dispatchActions[BAR_KS_COUNT] = {
 				"act_songpause"},
 		{'^', BAR_DC_GLOBAL, BarUiActVolReset, "reset volume",
 				"act_volreset"},
+		{'f', BAR_DC_GLOBAL, BarUiActToggleExplicitContentFilter, "toggle explicit content filter",
+				"act_explicitcontentfiltertoggle"},
 		};
 
 #include <piano.h>


### PR DESCRIPTION
This adds the ability to toggle the explicit content filter using 'f' as a shortcut. This was requested in https://github.com/PromyLOPh/pianobar/issues/506.

Unfortunately I was not able to use the `user.changeSettings` method and was getting a code 9 error back. It wasn't very clear which key it was expecting. `user.setExplicitContentFilter` works fine though! :smile: 

I hesitated from having `PIANO_REQUEST_GET_SETTINGS` fill in all the data in the relevant places, or adding a new struct with unused fields, instead only filling the new `PianoRequestDataGetExplicitContentFilterInfo_t` struct. Thoughts?