### PR TITLE
Increased delay, retries, etc

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -89,7 +89,7 @@ static bool BarMainGetLoginCredentials (BarSettings_t *settings,
 	if (settings->username == NULL) {
 		char nameBuf[100];
 
-		BarUiMsg (settings, MSG_QUESTION, "Email: ");
+		BarUiMsg (settings, MSG_QUESTION, "No User name in config? Email: ");
 		BarReadlineStr (nameBuf, sizeof (nameBuf), input, BAR_RL_DEFAULT);
 		settings->username = strdup (nameBuf);
 		usernameFromConfig = false;
@@ -99,7 +99,7 @@ static bool BarMainGetLoginCredentials (BarSettings_t *settings,
 		char passBuf[100];
 
 		if (usernameFromConfig) {
-			BarUiMsg (settings, MSG_QUESTION, "Email: %s\n", settings->username);
+			BarUiMsg (settings, MSG_QUESTION, "Got username Email: %s\n", settings->username);
 		}
 
 		if (settings->passwordCmd == NULL) {
@@ -203,7 +203,7 @@ static void BarMainGetInitialStation (BarApp_t *app) {
 static void BarMainHandleUserInput (BarApp_t *app) {
 	char buf[2];
 	if (BarReadline (buf, sizeof (buf), NULL, &app->input,
-			BAR_RL_FULLRETURN | BAR_RL_NOECHO, 1) > 0) {
+			BAR_RL_FULLRETURN | BAR_RL_NOECHO, 2) > 0) {
 		BarUiDispatch (app, buf[0], app->curStation, app->playlist, true,
 				BAR_DC_GLOBAL);
 	}
@@ -433,35 +433,41 @@ int main (int argc, char **argv) {
 
 	/* init fds */
 	FD_ZERO(&app.input.set);
+
+        int fifo_uses_this_fd = 0;
 	app.input.fds[0] = STDIN_FILENO;
-	FD_SET(app.input.fds[0], &app.input.set);
+        if (isatty(fileno(stdin))) {
+	    fifo_uses_this_fd = 1;
+	    FD_SET(app.input.fds[0], &app.input.set);
+            }
 
 	/* open fifo read/write so it won't EOF if nobody writes to it */
 	assert (sizeof (app.input.fds) / sizeof (*app.input.fds) >= 2);
-	app.input.fds[1] = open (app.settings.fifo, O_RDWR);
-	if (app.input.fds[1] != -1) {
+	app.input.fds[fifo_uses_this_fd] = open (app.settings.fifo, O_RDWR);
+	if (app.input.fds[fifo_uses_this_fd] != -1) {
 		struct stat s;
 
 		/* check for file type, must be fifo */
-		fstat (app.input.fds[1], &s);
+		fstat (app.input.fds[fifo_uses_this_fd], &s);
 		if (!S_ISFIFO (s.st_mode)) {
 			BarUiMsg (&app.settings, MSG_ERR, "File at %s is not a fifo\n", app.settings.fifo);
-			close (app.input.fds[1]);
-			app.input.fds[1] = -1;
+			close (app.input.fds[fifo_uses_this_fd]);
+			app.input.fds[fifo_uses_this_fd] = -1;
 		} else {
-			FD_SET(app.input.fds[1], &app.input.set);
+			FD_SET(app.input.fds[fifo_uses_this_fd], &app.input.set);
 			BarUiMsg (&app.settings, MSG_INFO, "Control fifo at %s opened\n",
 					app.settings.fifo);
 		}
 	}
-	app.input.maxfd = app.input.fds[0] > app.input.fds[1] ? app.input.fds[0] :
-			app.input.fds[1];
+        app.input.maxfd = app.input.fds[0];
+        if (fifo_uses_this_fd>0)
+		app.input.maxfd = app.input.fds[0] > app.input.fds[1] ? app.input.fds[0] : app.input.fds[1];
 	++app.input.maxfd;
 
 	BarMainLoop (&app);
 
-	if (app.input.fds[1] != -1) {
-		close (app.input.fds[1]);
+	if (app.input.fds[fifo_uses_this_fd] != -1) {
+		close (app.input.fds[fifo_uses_this_fd]);
 	}
 
 	/* write statefile */

--- a/src/ui.c
+++ b/src/ui.c
@@ -38,6 +38,7 @@ THE SOFTWARE.
 #include <strings.h>
 #include <assert.h>
 #include <ctype.h> /* tolower() */
+#include <fcntl.h>
 
 /* waitpid () */
 #include <sys/types.h>
@@ -45,6 +46,7 @@ THE SOFTWARE.
 
 #include "ui.h"
 #include "ui_readline.h"
+
 
 typedef int (*BarSortFunc_t) (const void *, const void *);
 
@@ -95,6 +97,11 @@ static const char *BarStrCaseStr (const char *haystack, const char *needle) {
  */
 void BarUiMsg (const BarSettings_t *settings, const BarUiMsg_t type,
 		const char *format, ...) {
+        // GD
+#define PB_MESSAGE_FILE "/tmp/pianobar_messages.txt"
+        char iobuf[4096];
+        FILE *uibuffer = stdout;
+
 	va_list fmtargs;
 
 	assert (settings != NULL);
@@ -102,34 +109,45 @@ void BarUiMsg (const BarSettings_t *settings, const BarUiMsg_t type,
 	assert (format != NULL);
 
 	switch (type) {
-		case MSG_INFO:
 		case MSG_PLAYING:
-		case MSG_TIME:
 		case MSG_ERR:
-		case MSG_QUESTION:
+			if (!isatty(fileno(stdin))) uibuffer = fopen(PB_MESSAGE_FILE,"w"); // important: clear buffer first
+			fputs( "@P2 ", uibuffer);
+                        break;
 		case MSG_LIST:
-			/* print ANSI clear line */
-			fputs ("\033[2K", stdout);
-			break;
-
+		case MSG_INFO:
+		case MSG_TIME:
+		case MSG_QUESTION:
 		default:
+			if (!isatty(fileno(stdin))) uibuffer = fopen(PB_MESSAGE_FILE,"a"); // add text to buffer
+                        break;
+
+			/* print ANSI clear line */
+			fputs ("\033[2K", uibuffer);
 			break;
 	}
 
 	if (settings->msgFormat[type].prefix != NULL) {
-		fputs (settings->msgFormat[type].prefix, stdout);
+		fputs (settings->msgFormat[type].prefix, uibuffer);
 	}
 
 	va_start (fmtargs, format);
-	vprintf (format, fmtargs);
+	vsprintf (iobuf, format, fmtargs);
 	va_end (fmtargs);
 
+        fputs( iobuf, uibuffer);
+
+
 	if (settings->msgFormat[type].postfix != NULL) {
-		fputs (settings->msgFormat[type].postfix, stdout);
+		// if (uibuffer!=stdout) fputs (settings->msgFormat[type].postfix, stdout);
+		fputs (settings->msgFormat[type].postfix, uibuffer);
 	}
 
-	fflush (stdout);
+	fflush(uibuffer);
+
+        if (!isatty(fileno(stdin))) fclose(uibuffer);
 }
+
 
 typedef struct {
 	char *data;


### PR DESCRIPTION
There are a few different changes combined here, not all of which may be of general interest.
1) There are changes to allow stdin to be redirected from a file or /dev/null without disaster.
2) In such cases, status messages are written to a file in /tmp so thay can be more readily recovered by another client.  This is a bit ugly, but as opposed to using a pipe or a FIFO, it allows other processes that talk to pianobar to come and go.
3) There are a changes to player.c to increase robustness to very slow network connections.
4) There are a few cosmetic changes in the diagnostic messages, basically to assist me in debugging.
