### PR TITLE
Add songpause, songplay, and pianoquit EventCmds for external scripts

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -480,6 +480,10 @@ int main (int argc, char **argv) {
 
 	BarMainLoop (&app);
 
+	BarUiStartEventCmd (&app.settings, "pianoquit",
+		app.curStation, NULL, &app.player, app.ph.stations,
+		PIANO_RET_OK, CURLE_OK);
+
 	if (app.input.fds[1] != -1) {
 		close (app.input.fds[1]);
 	}

--- a/src/ui.c
+++ b/src/ui.c
@@ -827,8 +827,8 @@ void BarUiStartEventCmd (const BarSettings_t *settings, const char *type,
 				PianoErrorToStr (pRet),
 				wRet,
 				curl_easy_strerror (wRet),
-				player->songDuration,
-				player->songPlayed,
+				player == NULL ? 0 : player->songDuration,
+				player == NULL ? 0 : player->songPlayed,
 				curSong == NULL ? PIANO_RATE_NONE : curSong->rating,
 				curSong == NULL ? "" : curSong->detailUrl
 				);

--- a/src/ui_act.c
+++ b/src/ui_act.c
@@ -415,6 +415,11 @@ BarUiActCallback(BarUiActSkipSong) {
 BarUiActCallback(BarUiActPlay) {
 	pthread_mutex_lock (&app->player.pauseMutex);
 	app->player.doPause = false;
+
+	BarUiStartEventCmd (&app->settings, "songplay",
+		selStation, selSong, &app->player, NULL,
+		PIANO_RET_OK, CURLE_OK);
+
 	pthread_cond_broadcast (&app->player.pauseCond);
 	pthread_mutex_unlock (&app->player.pauseMutex);
 }
@@ -424,6 +429,11 @@ BarUiActCallback(BarUiActPlay) {
 BarUiActCallback(BarUiActPause) {
 	pthread_mutex_lock (&app->player.pauseMutex);
 	app->player.doPause = true;
+
+	BarUiStartEventCmd (&app->settings, "songpause",
+		selStation, selSong, &app->player, NULL,
+		PIANO_RET_OK, CURLE_OK);
+
 	pthread_cond_broadcast (&app->player.pauseCond);
 	pthread_mutex_unlock (&app->player.pauseMutex);
 }
@@ -433,6 +443,17 @@ BarUiActCallback(BarUiActPause) {
 BarUiActCallback(BarUiActTogglePause) {
 	pthread_mutex_lock (&app->player.pauseMutex);
 	app->player.doPause = !app->player.doPause;
+
+	if (app->player.doPause) {
+		BarUiStartEventCmd (&app->settings, "songpause",
+			selStation, selSong, &app->player, NULL,
+			PIANO_RET_OK, CURLE_OK);
+	} else {
+		BarUiStartEventCmd (&app->settings, "songplay",
+			selStation, selSong, &app->player, NULL,
+			PIANO_RET_OK, CURLE_OK);
+	}
+
 	pthread_cond_broadcast (&app->player.pauseCond);
 	pthread_mutex_unlock (&app->player.pauseMutex);
 }


### PR DESCRIPTION
I needed these event cmds for my lemonbar scripts to properly and responsively show when I have paused pianobar and when it has quit. I think it may be useful for others too. Let me know if it's missing something or if it's not up to par so I can fix any remaining issues.

Thanks,
fengshaun