### PR TITLE
Add songplay and songpause events.

### DIFF
--- a/src/ui_act.c
+++ b/src/ui_act.c
@@ -417,28 +417,45 @@ BarUiActCallback(BarUiActSkipSong) {
 /*	play
  */
 BarUiActCallback(BarUiActPlay) {
+	PianoReturn_t pRet;
+	CURLcode wRet;
+
 	pthread_mutex_lock (&app->player.pauseMutex);
 	app->player.doPause = false;
 	pthread_cond_broadcast (&app->player.pauseCond);
 	pthread_mutex_unlock (&app->player.pauseMutex);
+	BarUiActDefaultEventcmd ("songplay");
 }
 
 /*	pause
  */
 BarUiActCallback(BarUiActPause) {
+	PianoReturn_t pRet;
+	CURLcode wRet;
+
 	pthread_mutex_lock (&app->player.pauseMutex);
 	app->player.doPause = true;
 	pthread_cond_broadcast (&app->player.pauseCond);
 	pthread_mutex_unlock (&app->player.pauseMutex);
+	BarUiActDefaultEventcmd ("songpause");
 }
 
 /*	toggle pause
  */
 BarUiActCallback(BarUiActTogglePause) {
+	PianoReturn_t pRet;
+	CURLcode wRet;
+
 	pthread_mutex_lock (&app->player.pauseMutex);
 	app->player.doPause = !app->player.doPause;
 	pthread_cond_broadcast (&app->player.pauseCond);
 	pthread_mutex_unlock (&app->player.pauseMutex);
+	if (app->player.doPause) {
+		BarUiActDefaultEventcmd ("songpause");
+	}
+	else {
+		BarUiActDefaultEventcmd ("songplay");
+	}
 }
 
 /*	rename current station


### PR DESCRIPTION
New songplay and songpause events occure when a song gets played or paused, allowing headless clients to easily see the play/pause status of pianobar without parsing stdout. When used with the given songPlayed/songDuration data, one can easily calculate the current position in the track.

I am also trying to get prompts, like add station, and add genre, and potential username/password prompts to create events. With the selection list using the same code from station list. However, I have yet to complete it and I figured you were more likely to have complaints with its code than this, so I will leave that for a latter pull request.
