### PR TITLE
add bind_to feature to support VPN's

### DIFF
--- a/contrib/config-example
+++ b/contrib/config-example
@@ -10,7 +10,7 @@
 
 # Proxy (for those who are not living in the USA)
 #control_proxy = http://127.0.0.1:9090/
-#bind_to = tun0
+#bind_to = if!tun0
 
 # Keybindings
 #act_help = ?

--- a/contrib/config-example
+++ b/contrib/config-example
@@ -10,6 +10,7 @@
 
 # Proxy (for those who are not living in the USA)
 #control_proxy = http://127.0.0.1:9090/
+#bind_to = tun0
 
 # Keybindings
 #act_help = ?

--- a/contrib/pianobar.1
+++ b/contrib/pianobar.1
@@ -208,6 +208,29 @@ Non-american users need a proxy to use pandora.com. Only the xmlrpc interface
 will use this proxy. The music is streamed directly.
 
 .TP
+.B bind_to = {if!tunX,host!x.x.x.x,..}
+This sets the interface name to use as outgoing network interface. The name can be an interface name, an IP address, or a host name. (from CURLOPT_INTERFACE)
+.RS
+It can be used to bind pianobar to vpn connection. 
+Example openvpn client config file:
+.nf
+
+client
+dev tun
+proto tcp
+remote x.x.x.x x
+nobind
+tls-client
+tls-auth /etc/openvpn/tls.key 1
+ca /etc/openvpn/ca.crt
+persist-tun
+[...]
+.fi
+.B route-nopull 
+#! to keep existing gateway and routing (don't pass whole machine traffic by vpn)
+.RE
+
+.TP
 .B decrypt_password = R=U!LH$O2B#
 
 .TP

--- a/src/settings.c
+++ b/src/settings.c
@@ -111,6 +111,7 @@ void BarSettingsInit (BarSettings_t *settings) {
 void BarSettingsDestroy (BarSettings_t *settings) {
 	free (settings->controlProxy);
 	free (settings->proxy);
+	free (settings->bind_to);
 	free (settings->username);
 	free (settings->password);
 	free (settings->passwordCmd);
@@ -269,6 +270,8 @@ void BarSettingsRead (BarSettings_t *settings) {
 				settings->controlProxy = strdup (val);
 			} else if (streq ("proxy", key)) {
 				settings->proxy = strdup (val);
+			} else if (streq ("bind_to", key)) {
+				settings->bind_to = strdup (val);
 			} else if (streq ("user", key)) {
 				settings->username = strdup (val);
 			} else if (streq ("password", key)) {

--- a/src/settings.c
+++ b/src/settings.c
@@ -111,7 +111,7 @@ void BarSettingsInit (BarSettings_t *settings) {
 void BarSettingsDestroy (BarSettings_t *settings) {
 	free (settings->controlProxy);
 	free (settings->proxy);
-	free (settings->bind_to);
+	free (settings->bindTo);
 	free (settings->username);
 	free (settings->password);
 	free (settings->passwordCmd);
@@ -271,7 +271,7 @@ void BarSettingsRead (BarSettings_t *settings) {
 			} else if (streq ("proxy", key)) {
 				settings->proxy = strdup (val);
 			} else if (streq ("bind_to", key)) {
-				settings->bind_to = strdup (val);
+				settings->bindTo = strdup (val);
 			} else if (streq ("user", key)) {
 				settings->username = strdup (val);
 			} else if (streq ("password", key)) {

--- a/src/settings.h
+++ b/src/settings.h
@@ -93,6 +93,7 @@ typedef struct {
 	char *password, *passwordCmd;
 	char *controlProxy; /* non-american listeners need this */
 	char *proxy;
+	char *bind_to;
 	char *autostartStation;
 	char *eventCmd;
 	char *loveIcon;

--- a/src/settings.h
+++ b/src/settings.h
@@ -93,7 +93,7 @@ typedef struct {
 	char *password, *passwordCmd;
 	char *controlProxy; /* non-american listeners need this */
 	char *proxy;
-	char *bind_to;
+	char *bindTo;
 	char *autostartStation;
 	char *eventCmd;
 	char *loveIcon;

--- a/src/ui.c
+++ b/src/ui.c
@@ -209,12 +209,12 @@ static CURLcode BarPianoHttpRequest (CURL * const http,
 		setAndCheck (CURLOPT_CAINFO, settings->caBundle);
 	}
 
-      if (settings->bind_to!= NULL) {
+      if (settings->bindTo!= NULL) {
 		if (curl_easy_setopt (http, CURLOPT_INTERFACE,
-				settings->bind_to) != CURLE_OK) {
+				settings->bindTo) != CURLE_OK) {
 			/* if binding fails, notice about that */
-			BarUiMsg (settings, MSG_ERR, "bind_to (%s) is invalid!\n",
-					 settings->bind_to);
+			BarUiMsg (settings, MSG_ERR, "bindTo (%s) is invalid!\n",
+					 settings->bindTo);
 		}
       }
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -212,7 +212,7 @@ static CURLcode BarPianoHttpRequest (CURL * const http,
       if (settings->bind_to!= NULL) {
 		if (curl_easy_setopt (http, CURLOPT_INTERFACE,
 				settings->bind_to) != CURLE_OK) {
-			/* if binding fails, notice about thisd */
+			/* if binding fails, notice about that */
 			BarUiMsg (settings, MSG_ERR, "bind_to (%s) is invalid!\n",
 					 settings->bind_to);
 		}

--- a/src/ui.c
+++ b/src/ui.c
@@ -209,6 +209,15 @@ static CURLcode BarPianoHttpRequest (CURL * const http,
 		setAndCheck (CURLOPT_CAINFO, settings->caBundle);
 	}
 
+      if (settings->bind_to!= NULL) {
+		if (curl_easy_setopt (http, CURLOPT_INTERFACE,
+				settings->bind_to) != CURLE_OK) {
+			/* if setting proxy fails, url is invalid */
+			BarUiMsg (settings, MSG_ERR, "bind_to (%s) is invalid!\n",
+					 settings->bind_to);
+		}
+      }
+
 	/* set up proxy (control proxy for non-us citizen or global proxy for poor
 	 * firewalled fellows) */
 	if (settings->controlProxy != NULL) {

--- a/src/ui.c
+++ b/src/ui.c
@@ -212,7 +212,7 @@ static CURLcode BarPianoHttpRequest (CURL * const http,
       if (settings->bind_to!= NULL) {
 		if (curl_easy_setopt (http, CURLOPT_INTERFACE,
 				settings->bind_to) != CURLE_OK) {
-			/* if setting proxy fails, url is invalid */
+			/* if binding fails, notice about thisd */
 			BarUiMsg (settings, MSG_ERR, "bind_to (%s) is invalid!\n",
 					 settings->bind_to);
 		}


### PR DESCRIPTION
This change allows to bind pianobar to vpn interface and use it instead of proxy.
If you don't want to route whole traffic by vpn, that's the simples solution to use it only by pianobar.
Works fine for a while so I thought it's worth to share :)