### PR TITLE
Added gain_mul setting to soften effect of replaygain

### DIFF
--- a/contrib/pianobar.1
+++ b/contrib/pianobar.1
@@ -364,6 +364,12 @@ Your pandora.com username.
 .B volume = 0
 Initial volume correction in dB. Usually between -30 and +5.
 
+.TP
+.B gain_mul = 1.0
+Pandora sends a ReplayGain value with every song. This sets a multiplier so that the gain adjustment can be
+reduced. 0.0 means no gain adjustment, 1.0 means full gain adjustment, values inbetween reduce the magnitude
+of gain adjustment.
+
 .SH REMOTE CONTROL
 .B pianobar
 can be controlled through a fifo. You have to create it yourself by executing

--- a/src/player.c
+++ b/src/player.c
@@ -94,13 +94,13 @@ void BarPlayerSetVolume (player_t * const player) {
 	 * -> print to string and let them parse it again */
 	char strbuf[16];
 	snprintf (strbuf, sizeof (strbuf), "%fdB",
-			player->settings->volume + player->gain);
+			player->settings->volume + (player->gain * player->settings->gainMul));
 	assert (player->fgraph != NULL);
 	if ((ret = avfilter_graph_send_command (player->fgraph, "volume", "volume",
 					strbuf, NULL, 0, 0)) < 0) {
 #else
 	/* convert from decibel */
-	const double volume = pow (10, (player->settings->volume + player->gain) / 20);
+	const double volume = pow (10, (player->settings->volume + (player->gain * player->settings->gainMul)) / 20);
 	/* libav does not provide other means to set this right now. it might not
 	 * even work everywhere. */
 	assert (player->fvolume != NULL);

--- a/src/settings.c
+++ b/src/settings.c
@@ -160,6 +160,7 @@ void BarSettingsRead (BarSettings_t *settings) {
 	settings->autoselect = true;
 	settings->history = 5;
 	settings->volume = 0;
+	settings->gainMul = 1.0;
 	settings->maxPlayerErrors = 5;
 	settings->sortOrder = BAR_SORT_NAME_AZ;
 	settings->loveIcon = strdup (" <3");
@@ -362,6 +363,8 @@ void BarSettingsRead (BarSettings_t *settings) {
 				settings->atIcon = strdup (val);
 			} else if (streq ("volume", key)) {
 				settings->volume = atoi (val);
+			} else if (streq ("gain_mul", key)) {
+				settings->gainMul = atof (val);
 			} else if (streq ("format_nowplaying_song", key)) {
 				free (settings->npSongFormat);
 				settings->npSongFormat = strdup (val);

--- a/src/settings.h
+++ b/src/settings.h
@@ -87,6 +87,7 @@ typedef struct {
 	bool autoselect;
 	unsigned int history, maxPlayerErrors;
 	int volume;
+	float gainMul;
 	BarStationSorting_t sortOrder;
 	PianoAudioQuality_t audioQuality;
 	char *username;


### PR DESCRIPTION
Recently, I was finding that the songs played by pianobar seemed very inconsistent in terms of volume levels. After digging into the issue a bit, it seems to be that the "fileGain" parameter sent along with every song is what was causing these variations. It seems that for most of the songs that my stations play, the gain reduction is too much. Thus, I added a config file setting to reduce the gain amount with a multiplier.

I personally have a Pandora One (Plus?) account, so I only use the high-quality streams. From a quick inspection of the audio files, it seems like the high-quality streams are 32-bit floatle AAC streams in an mp4 container. At least one of the songs I inspected had audio samples above 1.0, so it seems that the negative gain is necessary to prevent clipping (most of the songs I inspected called for negative gains in the range of -1 to -6 dB).

The example song I can point to is "Can't Kill Us" by "The Glitch Mob" on "Love Death Immortality".  Here is the debug output for that track:

> album:4:Love Death Immortality
> artist: The Glitch Mob
> audioFormat:    1
> audioUrl:       http://mediaserver-sv5-rt-1-v4v6.pandora.com/access/3030659617253320487.mp4?version=5&lid=4066191&token=PnyUHXJl3niIzPuVKqUkfPeaFpsozSheC7N8ZSZiCx3YQ3rX8AeFzCdNqnxGfoQwey%2B%2B3LP4kTdWtrMhR00jVWk6Qe3s3679W%2BWGlsTVKIrZ6Dv%2BQsbbu6HOx326ewJm1zX%2FNmMQOIgaCzuG2%2FWjBfcE%2F4YSRoZOI6BbGg63VDTuvuqQFJGqEG%2Fi8miNsG%2BtcUPTqKGKxSCV4qSUOR1U2juL%2FPBkFOHuUYeZFbL2VPo6pJoRPVFnvQcZ6o4OK4Z4hPjqXsCutkz0XdslIpfOmCx2zgGeBTtIz51mbcXY5cne1QViud8lK83S3GUupvP83IqfyCbbgSnkfafkzpumUCCr4jFWUaGrv63f4L71eWTOZcFOlfdMiKDbGgewn7%2FPfYVQupRg8%2FKzbKRTBDAHNq%2BMUkf5XDNkoj2H4UAdJ9zm%2Fx4DrN1lioBLk3JhFcK1gYcEb00YJyJCH1jupi5R5Pm1fl8Ku3gKtUtogEcOv9OLW8Qvuc6VqwUBr3EIGs0GeogkbvXezO%2Fi4CWcArvR6vrxAg0xD6hwcEYaYdG01kU%3D
> coverArt:       http://cont-2.p-cdn.com/images/public/int/1/0/0/2/885686932001_500W_500H.jpg
> detailUrl:      http://www.pandora.com/glitch-mob/love-death-immortality/cant-kill-us?dc=232&ad=0:23:1:12866::0:0:0:0:532:069:NY:36091:2:0:0:0:0:1
> fileGain:       -5.820000
> musicId:        (null)
> rating: 1
> stationId:      1572974726408440719
> title:  Can't Kill Us
> trackToken:     PaCsomnacRvAbMXyncr3d5Qw8Mf2kAWvm-0dqf3BHK7sD7KJ3YkvZuMGXZvsMaDpOFsCzmAnlbDp2_AhqvUl_Eg

Note the requested gain amount of -5.82 dB. Upon inspecting the file in Audacity, the highest sample is at +3.81 dB (and that seems to be a stray transient). Realistically, this gain reduction makes the song play at half volume.

This patch may not be the best way of solving this problem, but I'm currently unable to come up with anything better. I'm definitely open to suggestions.