### PR TITLE
Add login retry functionality

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -82,7 +82,7 @@ static bool BarMainGetLoginCredentials (BarSettings_t *settings,
 		BarReadlineFds_t *input) {
 	bool usernameFromConfig = true;
 
-	if (settings->username == NULL) {
+	if (settings->config_username == NULL) {
 		char nameBuf[100];
 
 		BarUiMsg (settings, MSG_QUESTION, "Email: ");
@@ -91,9 +91,11 @@ static bool BarMainGetLoginCredentials (BarSettings_t *settings,
 		}
 		settings->username = strdup (nameBuf);
 		usernameFromConfig = false;
+	} else {
+		settings->username = strdup (settings->config_username);
 	}
 
-	if (settings->password == NULL) {
+	if (settings->config_password == NULL) {
 		char passBuf[100];
 
 		if (usernameFromConfig) {
@@ -158,6 +160,8 @@ static bool BarMainGetLoginCredentials (BarSettings_t *settings,
 				}
 			}
 		} /* end else passwordCmd */
+	} else {
+	    settings->password = strdup (settings->config_password);
 	}
 
 	return true;
@@ -337,12 +341,23 @@ static void BarMainPrintTime (BarApp_t *app) {
 static void BarMainLoop (BarApp_t *app) {
 	pthread_t playerThread;
 
-	if (!BarMainGetLoginCredentials (&app->settings, &app->input)) {
-		return;
+	bool login_success = false;
+
+	for (int i = 0;
+	     !login_success && i < app->settings.num_login_tries;
+	     i++)
+	{
+		login_success = BarMainGetLoginCredentials (&app->settings, &app->input)
+		    && BarMainLoginUser(app);
+
+		if (!login_success) {
+			free (app->settings.username);
+			free (app->settings.password);
+		}
 	}
 
-	if (!BarMainLoginUser (app)) {
-		return;
+	if (!login_success) {
+	    return;
 	}
 
 	if (!BarMainGetStations (app)) {

--- a/src/main.c
+++ b/src/main.c
@@ -352,7 +352,9 @@ static void BarMainLoop (BarApp_t *app) {
 
 		if (!login_success) {
 			free (app->settings.username);
+			app->settings.username = NULL;
 			free (app->settings.password);
+			app->settings.password = NULL;
 		}
 	}
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -112,7 +112,9 @@ void BarSettingsDestroy (BarSettings_t *settings) {
 	free (settings->controlProxy);
 	free (settings->proxy);
 	free (settings->bindTo);
+	free (settings->config_username);
 	free (settings->username);
+	free (settings->config_password);
 	free (settings->password);
 	free (settings->passwordCmd);
 	free (settings->autostartStation);
@@ -156,6 +158,7 @@ void BarSettingsRead (BarSettings_t *settings) {
 			sizeof (dispatchActions) / sizeof (*dispatchActions));
 
 	/* apply defaults */
+	settings->num_login_tries = 1;
 	settings->audioQuality = PIANO_AQ_HIGH;
 	settings->autoselect = true;
 	settings->history = 5;
@@ -278,9 +281,9 @@ void BarSettingsRead (BarSettings_t *settings) {
 			} else if (streq ("bind_to", key)) {
 				settings->bindTo = strdup (val);
 			} else if (streq ("user", key)) {
-				settings->username = strdup (val);
+				settings->config_username = strdup (val);
 			} else if (streq ("password", key)) {
-				settings->password = strdup (val);
+				settings->config_password = strdup (val);
 			} else if (streq ("password_command", key)) {
 				settings->passwordCmd = strdup (val);
 			} else if (streq ("rpc_host", key)) {
@@ -409,6 +412,8 @@ void BarSettingsRead (BarSettings_t *settings) {
 						break;
 					}
 				}
+			} else if (streq ("num_login_tries", key)) {
+				settings->num_login_tries = atoi (val);
 			} else {
 				BarUiMsg (settings, MSG_INFO,
 						"Unrecognized key %s at %s:%zu\n", key, path, lineNum);

--- a/src/settings.h
+++ b/src/settings.h
@@ -86,11 +86,12 @@ typedef struct {
 	bool autoselect;
 	unsigned int history, maxPlayerErrors;
 	int volume;
+	int num_login_tries;
 	float gainMul;
 	BarStationSorting_t sortOrder;
 	PianoAudioQuality_t audioQuality;
-	char *username;
-	char *password, *passwordCmd;
+	char *config_username, *username;
+	char *config_password, *password, *passwordCmd;
 	char *controlProxy; /* non-american listeners need this */
 	char *proxy;
 	char *bindTo;


### PR DESCRIPTION
This patch adds a new setting in the config file: num_login_tries.  The
default value is 1 to match the current functionality.  If the value is
set larger, the program will retry up to this many times until there is
a successful login, or the number of tries has been exhausted.

In order to correctly accomplish this new piece of functionality, I had
to add two values to the settings struct to keep track of the values of
the username and password from the config file separate from those that
have been created by looking them up so that they can be reset upon
failure.

Lightly tested without any problems.