### PR TITLE
Resample output audio format based on configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ LIBPIANO_OBJ:=${LIBPIANO_SRC:.c=.o}
 LIBPIANO_RELOBJ:=${LIBPIANO_SRC:.c=.lo}
 LIBPIANO_INCLUDE:=${LIBPIANO_DIR}
 
-LIBAV_CFLAGS:=$(shell pkg-config --cflags libavcodec libavformat libavutil libavfilter)
-LIBAV_LDFLAGS:=$(shell pkg-config --libs libavcodec libavformat libavutil libavfilter)
+LIBAV_CFLAGS:=$(shell pkg-config --cflags libavcodec libavformat libavutil libavfilter libswresample)
+LIBAV_LDFLAGS:=$(shell pkg-config --libs libavcodec libavformat libavutil libavfilter libswresample)
 
 LIBCURL_CFLAGS:=$(shell pkg-config --cflags libcurl)
 LIBCURL_LDFLAGS:=$(shell pkg-config --libs libcurl)

--- a/contrib/config-example
+++ b/contrib/config-example
@@ -49,6 +49,7 @@
 #volume = 0
 #ca_bundle = /etc/ssl/certs/ca-certificates.crt
 #gain_mul = 1.0
+#sample_rate = 44100
 
 # Format strings
 #format_nowplaying_song = [32m%t[0m by [34m%a[0m on %l[31m%r[0m%@%s

--- a/src/player.c
+++ b/src/player.c
@@ -473,7 +473,7 @@ static void finish (player_t * const player) {
 		avformat_close_input (&player->fctx);
 	}
 	if (player->swrctx != NULL) {
-	  swr_close(player->swrctx);
+		swr_close(player->swrctx);
 	}
 }
 
@@ -531,7 +531,6 @@ void *BarAoPlayThread (void *data) {
 	while (!shouldQuit(player)) {
 		pthread_mutex_lock (&player->aoplayLock);
 
-	  // NOTE samples are gotten here
 		ret = av_buffersink_get_frame (player->fbufsink, filteredFrame);
 
 		if (ret == AVERROR_EOF || shouldQuit (player)) {
@@ -546,28 +545,28 @@ void *BarAoPlayThread (void *data) {
 			continue;
 		}
 
-	  // same channel layout and format assumed
-	  resampledFrame->channel_layout = filteredFrame->channel_layout;
-	  resampledFrame->format = filteredFrame->format;
-	  resampledFrame->sample_rate = player->settings->sampleRate;
-	  ret = swr_config_frame(player->swrctx, resampledFrame, filteredFrame);
-	  if (ret) {
-	    // ERROR
-	    pthread_mutex_unlock(&player->aoplayLock);
-	    break;
-	  }
+		// same channel layout and format assumed
+		resampledFrame->channel_layout = filteredFrame->channel_layout;
+		resampledFrame->format = filteredFrame->format;
+		resampledFrame->sample_rate = player->settings->sampleRate;
+		ret = swr_config_frame(player->swrctx, resampledFrame, filteredFrame);
+		if (ret) {
+		  // ERROR
+		  pthread_mutex_unlock(&player->aoplayLock);
+		  break;
+		}
 
-	  // resample frame
-	  ret = swr_convert_frame(player->swrctx, resampledFrame, filteredFrame);
-	  if (ret) {
-	    pthread_mutex_unlock(&player->aoplayLock);
-	    break;
-	  }
+		// resample frame
+		ret = swr_convert_frame(player->swrctx, resampledFrame, filteredFrame);
+		if (ret) {
+		  pthread_mutex_unlock(&player->aoplayLock);
+		  break;
+		}
 
 		pthread_mutex_unlock (&player->aoplayLock);
-	  const int numChannels = av_get_channel_layout_nb_channels (
-	                  resampledFrame->channel_layout);
-	  const int bps = av_get_bytes_per_sample (resampledFrame->format);
+		const int numChannels = av_get_channel_layout_nb_channels (
+		                resampledFrame->channel_layout);
+		const int bps = av_get_bytes_per_sample (resampledFrame->format);
 		ao_play (player->aoDev, (char *) resampledFrame->data[0],
 				resampledFrame->nb_samples * numChannels * bps);
 
@@ -594,7 +593,7 @@ void *BarAoPlayThread (void *data) {
 		pthread_mutex_unlock (&player->aoplayLock);
 
 		av_frame_unref (filteredFrame);
-	  av_frame_unref (resampledFrame);
+		av_frame_unref (resampledFrame);
 	}
 	av_frame_free (&filteredFrame);
 	av_frame_free (&resampledFrame);

--- a/src/player.c
+++ b/src/player.c
@@ -190,6 +190,7 @@ static bool openStream (player_t * const player) {
 	player->fctx = avformat_alloc_context ();
 	player->fctx->interrupt_callback.callback = intCb;
 	player->fctx->interrupt_callback.opaque = player;
+  player->swrctx = swr_alloc();
 
 	/* in microseconds */
 	unsigned long int timeout = player->settings->timeout*1000000;
@@ -471,6 +472,9 @@ static void finish (player_t * const player) {
 	if (player->fctx != NULL) {
 		avformat_close_input (&player->fctx);
 	}
+  if (player->swrctx != NULL) {
+    swr_close(player->swrctx);
+  }
 }
 
 /*	player thread; for every song a new thread is started
@@ -514,16 +518,22 @@ void *BarAoPlayThread (void *data) {
 
 	player_t * const player = data;
 
-	AVFrame *filteredFrame = NULL;
+	AVFrame *filteredFrame = NULL, *resampledFrame = NULL;
 	filteredFrame = av_frame_alloc ();
 	assert (filteredFrame != NULL);
+  resampledFrame = av_frame_alloc ();
+  assert (resampledFrame != NULL);
 
 	int ret;
 	const double timeBase = av_q2d (av_buffersink_get_time_base (player->fbufsink)),
 			timeBaseSt = av_q2d (player->st->time_base);
+
 	while (!shouldQuit(player)) {
 		pthread_mutex_lock (&player->aoplayLock);
+
+    // NOTE samples are gotten here
 		ret = av_buffersink_get_frame (player->fbufsink, filteredFrame);
+
 		if (ret == AVERROR_EOF || shouldQuit (player)) {
 			/* we are done here */
 			pthread_mutex_unlock (&player->aoplayLock);
@@ -535,13 +545,31 @@ void *BarAoPlayThread (void *data) {
 			pthread_mutex_unlock (&player->aoplayLock);
 			continue;
 		}
-		pthread_mutex_unlock (&player->aoplayLock);
 
-		const int numChannels = av_get_channel_layout_nb_channels (
-				filteredFrame->channel_layout);
-		const int bps = av_get_bytes_per_sample (filteredFrame->format);
-		ao_play (player->aoDev, (char *) filteredFrame->data[0],
-				filteredFrame->nb_samples * numChannels * bps);
+    // same channel layout and format assumed
+    resampledFrame->channel_layout = filteredFrame->channel_layout;
+    resampledFrame->format = filteredFrame->format;
+    resampledFrame->sample_rate = player->settings->sampleRate;
+    ret = swr_config_frame(player->swrctx, resampledFrame, filteredFrame);
+    if (ret) {
+      // ERROR
+      pthread_mutex_unlock(&player->aoplayLock);
+      break;
+    }
+
+    // resample frame
+    ret = swr_convert_frame(player->swrctx, resampledFrame, filteredFrame);
+    if (ret) {
+      pthread_mutex_unlock(&player->aoplayLock);
+      break;
+    }
+
+		pthread_mutex_unlock (&player->aoplayLock);
+    const int numChannels = av_get_channel_layout_nb_channels (
+                    resampledFrame->channel_layout);
+    const int bps = av_get_bytes_per_sample (resampledFrame->format);
+		ao_play (player->aoDev, (char *) resampledFrame->data[0],
+				resampledFrame->nb_samples * numChannels * bps);
 
 		const double timestamp = (double) filteredFrame->pts * timeBase;
 		const unsigned int songPlayed = timestamp;
@@ -566,8 +594,10 @@ void *BarAoPlayThread (void *data) {
 		pthread_mutex_unlock (&player->aoplayLock);
 
 		av_frame_unref (filteredFrame);
+    av_frame_unref (resampledFrame);
 	}
 	av_frame_free (&filteredFrame);
+  av_frame_free (&resampledFrame);
 
 	return (void *) 0;
 }

--- a/src/player.c
+++ b/src/player.c
@@ -190,7 +190,7 @@ static bool openStream (player_t * const player) {
 	player->fctx = avformat_alloc_context ();
 	player->fctx->interrupt_callback.callback = intCb;
 	player->fctx->interrupt_callback.opaque = player;
-  player->swrctx = swr_alloc();
+	player->swrctx = swr_alloc();
 
 	/* in microseconds */
 	unsigned long int timeout = player->settings->timeout*1000000;
@@ -472,9 +472,9 @@ static void finish (player_t * const player) {
 	if (player->fctx != NULL) {
 		avformat_close_input (&player->fctx);
 	}
-  if (player->swrctx != NULL) {
-    swr_close(player->swrctx);
-  }
+	if (player->swrctx != NULL) {
+	  swr_close(player->swrctx);
+	}
 }
 
 /*	player thread; for every song a new thread is started
@@ -521,8 +521,8 @@ void *BarAoPlayThread (void *data) {
 	AVFrame *filteredFrame = NULL, *resampledFrame = NULL;
 	filteredFrame = av_frame_alloc ();
 	assert (filteredFrame != NULL);
-  resampledFrame = av_frame_alloc ();
-  assert (resampledFrame != NULL);
+	resampledFrame = av_frame_alloc ();
+	assert (resampledFrame != NULL);
 
 	int ret;
 	const double timeBase = av_q2d (av_buffersink_get_time_base (player->fbufsink)),
@@ -531,7 +531,7 @@ void *BarAoPlayThread (void *data) {
 	while (!shouldQuit(player)) {
 		pthread_mutex_lock (&player->aoplayLock);
 
-    // NOTE samples are gotten here
+	  // NOTE samples are gotten here
 		ret = av_buffersink_get_frame (player->fbufsink, filteredFrame);
 
 		if (ret == AVERROR_EOF || shouldQuit (player)) {
@@ -546,28 +546,28 @@ void *BarAoPlayThread (void *data) {
 			continue;
 		}
 
-    // same channel layout and format assumed
-    resampledFrame->channel_layout = filteredFrame->channel_layout;
-    resampledFrame->format = filteredFrame->format;
-    resampledFrame->sample_rate = player->settings->sampleRate;
-    ret = swr_config_frame(player->swrctx, resampledFrame, filteredFrame);
-    if (ret) {
-      // ERROR
-      pthread_mutex_unlock(&player->aoplayLock);
-      break;
-    }
+	  // same channel layout and format assumed
+	  resampledFrame->channel_layout = filteredFrame->channel_layout;
+	  resampledFrame->format = filteredFrame->format;
+	  resampledFrame->sample_rate = player->settings->sampleRate;
+	  ret = swr_config_frame(player->swrctx, resampledFrame, filteredFrame);
+	  if (ret) {
+	    // ERROR
+	    pthread_mutex_unlock(&player->aoplayLock);
+	    break;
+	  }
 
-    // resample frame
-    ret = swr_convert_frame(player->swrctx, resampledFrame, filteredFrame);
-    if (ret) {
-      pthread_mutex_unlock(&player->aoplayLock);
-      break;
-    }
+	  // resample frame
+	  ret = swr_convert_frame(player->swrctx, resampledFrame, filteredFrame);
+	  if (ret) {
+	    pthread_mutex_unlock(&player->aoplayLock);
+	    break;
+	  }
 
 		pthread_mutex_unlock (&player->aoplayLock);
-    const int numChannels = av_get_channel_layout_nb_channels (
-                    resampledFrame->channel_layout);
-    const int bps = av_get_bytes_per_sample (resampledFrame->format);
+	  const int numChannels = av_get_channel_layout_nb_channels (
+	                  resampledFrame->channel_layout);
+	  const int bps = av_get_bytes_per_sample (resampledFrame->format);
 		ao_play (player->aoDev, (char *) resampledFrame->data[0],
 				resampledFrame->nb_samples * numChannels * bps);
 
@@ -594,10 +594,10 @@ void *BarAoPlayThread (void *data) {
 		pthread_mutex_unlock (&player->aoplayLock);
 
 		av_frame_unref (filteredFrame);
-    av_frame_unref (resampledFrame);
+	  av_frame_unref (resampledFrame);
 	}
 	av_frame_free (&filteredFrame);
-  av_frame_free (&resampledFrame);
+	av_frame_free (&resampledFrame);
 
 	return (void *) 0;
 }

--- a/src/player.h
+++ b/src/player.h
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #include <ao/ao.h>
 #include <libavformat/avformat.h>
 #include <libavfilter/avfilter.h>
+#include <libswresample/swresample.h>
 #include <piano.h>
 
 #include "settings.h"
@@ -70,6 +71,7 @@ typedef struct {
 	AVStream *st;
 	AVCodecContext *cctx;
 	AVFilterContext *fbufsink, *fabuf;
+  SwrContext *swrctx;
 	int streamIdx;
 	int64_t lastTimestamp;
 	sig_atomic_t interrupted;

--- a/src/settings.c
+++ b/src/settings.c
@@ -183,6 +183,7 @@ void BarSettingsRead (BarSettings_t *settings) {
 	settings->outkey = strdup ("6#26FRL$ZWD");
 	settings->fifo = BarGetXdgConfigDir (PACKAGE "/ctl");
 	assert (settings->fifo != NULL);
+  settings->sampleRate = 44100;
 
 	settings->msgFormat[MSG_NONE].prefix = NULL;
 	settings->msgFormat[MSG_NONE].postfix = NULL;
@@ -391,6 +392,8 @@ void BarSettingsRead (BarSettings_t *settings) {
 				settings->fifo = BarSettingsExpandTilde (val, userhome);
 			} else if (streq ("autoselect", key)) {
 				settings->autoselect = atoi (val);
+			} else if (streq ("sample_rate", key)) {
+				settings->sampleRate = atoi (val);
 			} else if (strncmp (formatMsgPrefix, key,
 					strlen (formatMsgPrefix)) == 0) {
 				static const char *mapping[] = {"none", "info", "nowplaying",

--- a/src/settings.c
+++ b/src/settings.c
@@ -183,7 +183,7 @@ void BarSettingsRead (BarSettings_t *settings) {
 	settings->outkey = strdup ("6#26FRL$ZWD");
 	settings->fifo = BarGetXdgConfigDir (PACKAGE "/ctl");
 	assert (settings->fifo != NULL);
-  settings->sampleRate = 44100;
+	settings->sampleRate = 44100;
 
 	settings->msgFormat[MSG_NONE].prefix = NULL;
 	settings->msgFormat[MSG_NONE].postfix = NULL;

--- a/src/settings.h
+++ b/src/settings.h
@@ -104,7 +104,7 @@ typedef struct {
 	char *fifo;
 	char *rpcHost, *rpcTlsPort, *partnerUser, *partnerPassword, *device, *inkey, *outkey, *caBundle;
 	char keys[BAR_KS_COUNT];
-  int sampleRate;
+	int sampleRate;
 	BarMsgFormatStr_t msgFormat[MSG_COUNT];
 } BarSettings_t;
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -104,6 +104,7 @@ typedef struct {
 	char *fifo;
 	char *rpcHost, *rpcTlsPort, *partnerUser, *partnerPassword, *device, *inkey, *outkey, *caBundle;
 	char keys[BAR_KS_COUNT];
+  int sampleRate;
 	BarMsgFormatStr_t msgFormat[MSG_COUNT];
 } BarSettings_t;
 


### PR DESCRIPTION
Resample output audio to a constant sampling rate as optionally specified in the configuration file, using libswresample