### PR TITLE
Named pipe output with libao

### DIFF
--- a/contrib/config-example
+++ b/contrib/config-example
@@ -49,6 +49,7 @@
 #volume = 0
 #ca_bundle = /etc/ssl/certs/ca-certificates.crt
 #gain_mul = 1.0
+#audio_pipe = /tmp/mypipe
 
 # Format strings
 #format_nowplaying_song = [32m%t[0m by [34m%a[0m on %l[31m%r[0m%@%s

--- a/src/player.c
+++ b/src/player.c
@@ -337,7 +337,7 @@ static bool openDevice (player_t * const player) {
   if (player->settings->audioPipe) {
     // using audio pipe
     struct stat st;
-    int fd = open(player->settings->audioPipe, O_RDONLY);
+    int fd = open(player->settings->audioPipe, O_RDWR);
     if (fd < 0) {
       BarUiMsg(player->settings, MSG_ERR, "Cannot open audio pipe file.\n");
       return false;

--- a/src/player.c
+++ b/src/player.c
@@ -350,6 +350,7 @@ static bool openDevice (player_t * const player) {
       BarUiMsg(player->settings, MSG_ERR, "File is not a pipe, error.\n");
       return false;
     }
+    close(fd);
     driver = ao_driver_id("raw");
     if ((player->aoDev = ao_open_file(driver, player->settings->audioPipe, 1, &aoFmt, NULL)) == NULL) {
       BarUiMsg(player->settings, MSG_ERR, "Cannot open audio pipe file.\n");

--- a/src/player.c
+++ b/src/player.c
@@ -38,9 +38,11 @@ THE SOFTWARE.
 #include <string.h>
 #include <math.h>
 #include <stdint.h>
+#include <fcntl.h>
 #include <limits.h>
 #include <assert.h>
 #include <arpa/inet.h>
+#include <sys/stat.h>
 
 #include <libavcodec/avcodec.h>
 #include <libavutil/avutil.h>
@@ -331,11 +333,37 @@ static bool openDevice (player_t * const player) {
 	aoFmt.rate = cp->sample_rate;
 	aoFmt.byte_format = AO_FMT_NATIVE;
 
-	int driver = ao_default_driver_id ();
-	if ((player->aoDev = ao_open_live (driver, &aoFmt, NULL)) == NULL) {
-		BarUiMsg (player->settings, MSG_ERR, "Cannot open audio device.\n");
-		return false;
-	}
+  int driver = -1;
+  if (player->settings->audioPipe) {
+    // using audio pipe
+    struct stat st;
+    int fd = open(player->settings->audioPipe, O_RDONLY);
+    if (fd < 0) {
+      BarUiMsg(player->settings, MSG_ERR, "Cannot open audio pipe file.\n");
+      return false;
+    }
+    if (fstat(fd, &st)) {
+      BarUiMsg(player->settings, MSG_ERR, "Cannot stat audio pipe file.\n");
+      return false;
+    }
+    if (!S_ISFIFO(st.st_mode)) {
+      BarUiMsg(player->settings, MSG_ERR, "File is not a pipe, error.\n");
+      return false;
+    }
+    driver = ao_driver_id("raw");
+    if ((player->aoDev = ao_open_file(driver, player->settings->audioPipe, 1, &aoFmt, NULL)) == NULL) {
+      BarUiMsg(player->settings, MSG_ERR, "Cannot open audio pipe file.\n");
+      return false;
+    }
+  }
+  else {
+    // use driver from libao configuration
+    driver = ao_default_driver_id ();
+    if ((player->aoDev = ao_open_live (driver, &aoFmt, NULL)) == NULL) {
+      BarUiMsg (player->settings, MSG_ERR, "Cannot open audio device.\n");
+      return false;
+    }
+  }
 
 	return true;
 }

--- a/src/player.c
+++ b/src/player.c
@@ -333,38 +333,38 @@ static bool openDevice (player_t * const player) {
 	aoFmt.rate = cp->sample_rate;
 	aoFmt.byte_format = AO_FMT_NATIVE;
 
-  int driver = -1;
-  if (player->settings->audioPipe) {
-    // using audio pipe
-    struct stat st;
-    int fd = open(player->settings->audioPipe, O_RDWR);
-    if (fd < 0) {
-      BarUiMsg(player->settings, MSG_ERR, "Cannot open audio pipe file.\n");
-      return false;
-    }
-    if (fstat(fd, &st)) {
-      BarUiMsg(player->settings, MSG_ERR, "Cannot stat audio pipe file.\n");
-      return false;
-    }
-    if (!S_ISFIFO(st.st_mode)) {
-      BarUiMsg(player->settings, MSG_ERR, "File is not a pipe, error.\n");
-      return false;
-    }
-    close(fd);
-    driver = ao_driver_id("raw");
-    if ((player->aoDev = ao_open_file(driver, player->settings->audioPipe, 1, &aoFmt, NULL)) == NULL) {
-      BarUiMsg(player->settings, MSG_ERR, "Cannot open audio pipe file.\n");
-      return false;
-    }
-  }
-  else {
-    // use driver from libao configuration
-    driver = ao_default_driver_id ();
-    if ((player->aoDev = ao_open_live (driver, &aoFmt, NULL)) == NULL) {
-      BarUiMsg (player->settings, MSG_ERR, "Cannot open audio device.\n");
-      return false;
-    }
-  }
+	int driver = -1;
+	if (player->settings->audioPipe) {
+	  // using audio pipe
+	  struct stat st;
+	  int fd = open(player->settings->audioPipe, O_RDWR);
+	  if (fd < 0) {
+	    BarUiMsg(player->settings, MSG_ERR, "Cannot open audio pipe file.\n");
+	    return false;
+	  }
+	  if (fstat(fd, &st)) {
+	    BarUiMsg(player->settings, MSG_ERR, "Cannot stat audio pipe file.\n");
+	    return false;
+	  }
+	  if (!S_ISFIFO(st.st_mode)) {
+	    BarUiMsg(player->settings, MSG_ERR, "File is not a pipe, error.\n");
+	    return false;
+	  }
+	  close(fd);
+	  driver = ao_driver_id("raw");
+	  if ((player->aoDev = ao_open_file(driver, player->settings->audioPipe, 1, &aoFmt, NULL)) == NULL) {
+	    BarUiMsg(player->settings, MSG_ERR, "Cannot open audio pipe file.\n");
+	    return false;
+	  }
+	}
+	else {
+	  // use driver from libao configuration
+	  driver = ao_default_driver_id ();
+	  if ((player->aoDev = ao_open_live (driver, &aoFmt, NULL)) == NULL) {
+	    BarUiMsg (player->settings, MSG_ERR, "Cannot open audio device.\n");
+	    return false;
+	  }
+	}
 
 	return true;
 }

--- a/src/settings.c
+++ b/src/settings.c
@@ -125,6 +125,7 @@ void BarSettingsDestroy (BarSettings_t *settings) {
 	free (settings->npStationFormat);
 	free (settings->listSongFormat);
 	free (settings->fifo);
+  free (settings->audioPipe);
 	free (settings->rpcHost);
 	free (settings->rpcTlsPort);
 	free (settings->partnerUser);
@@ -182,6 +183,7 @@ void BarSettingsRead (BarSettings_t *settings) {
 	settings->inkey = strdup ("R=U!LH$O2B#");
 	settings->outkey = strdup ("6#26FRL$ZWD");
 	settings->fifo = BarGetXdgConfigDir (PACKAGE "/ctl");
+  settings->audioPipe = NULL;
 	assert (settings->fifo != NULL);
 
 	settings->msgFormat[MSG_NONE].prefix = NULL;
@@ -389,6 +391,9 @@ void BarSettingsRead (BarSettings_t *settings) {
 			} else if (streq ("fifo", key)) {
 				free (settings->fifo);
 				settings->fifo = BarSettingsExpandTilde (val, userhome);
+			} else if (streq ("audio_pipe", key)) {
+				free (settings->audioPipe);
+				settings->audioPipe = BarSettingsExpandTilde (val, userhome);
 			} else if (streq ("autoselect", key)) {
 				settings->autoselect = atoi (val);
 			} else if (strncmp (formatMsgPrefix, key,

--- a/src/settings.c
+++ b/src/settings.c
@@ -125,7 +125,7 @@ void BarSettingsDestroy (BarSettings_t *settings) {
 	free (settings->npStationFormat);
 	free (settings->listSongFormat);
 	free (settings->fifo);
-  free (settings->audioPipe);
+	free (settings->audioPipe);
 	free (settings->rpcHost);
 	free (settings->rpcTlsPort);
 	free (settings->partnerUser);
@@ -183,7 +183,7 @@ void BarSettingsRead (BarSettings_t *settings) {
 	settings->inkey = strdup ("R=U!LH$O2B#");
 	settings->outkey = strdup ("6#26FRL$ZWD");
 	settings->fifo = BarGetXdgConfigDir (PACKAGE "/ctl");
-  settings->audioPipe = NULL;
+	settings->audioPipe = NULL;
 	assert (settings->fifo != NULL);
 
 	settings->msgFormat[MSG_NONE].prefix = NULL;

--- a/src/settings.h
+++ b/src/settings.h
@@ -103,7 +103,7 @@ typedef struct {
 	char *listSongFormat;
 	char *fifo;
 	char *rpcHost, *rpcTlsPort, *partnerUser, *partnerPassword, *device, *inkey, *outkey, *caBundle;
-  char *audioPipe;
+	char *audioPipe;
 	char keys[BAR_KS_COUNT];
 	BarMsgFormatStr_t msgFormat[MSG_COUNT];
 } BarSettings_t;

--- a/src/settings.h
+++ b/src/settings.h
@@ -103,6 +103,7 @@ typedef struct {
 	char *listSongFormat;
 	char *fifo;
 	char *rpcHost, *rpcTlsPort, *partnerUser, *partnerPassword, *device, *inkey, *outkey, *caBundle;
+  char *audioPipe;
 	char keys[BAR_KS_COUNT];
 	BarMsgFormatStr_t msgFormat[MSG_COUNT];
 } BarSettings_t;


### PR DESCRIPTION
Allow configurable output to use a named pipe with libao. This is particularly useful when using a multi-room audio setup with [snapcast](https://github.com/badaix/snapcast) for example.