### PR TITLE
removed some non-printable characters from the config example

### DIFF
--- a/contrib/config-example
+++ b/contrib/config-example
@@ -53,12 +53,12 @@
 #audio_pipe = /tmp/mypipe
 
 # Format strings
-#format_nowplaying_song = [32m%t[0m by [34m%a[0m on %l[31m%r[0m%@%s
-#format_nowplaying_song = [32m%t[0m by [34m%a[0m on %l%r%@%s
-#ban_icon =  [32m</3[0m
-#love_icon =  [31m<3[0m
-#tired_icon =  [33mzZ[0m
-#format_nowplaying_station = Station [35m%n[0m
+#format_nowplaying_song = [32m%t[0m by [34m%a[0m on %l[31m%r[0m%@%s
+#format_nowplaying_song = [32m%t[0m by [34m%a[0m on %l%r%@%s
+#ban_icon =  [32m</3[0m
+#love_icon =  [31m<3[0m
+#tired_icon =  [33mzZ[0m
+#format_nowplaying_station = Station [35m%n[0m
 #format_list_song = %i) %a - %t%r (%d)%@%s
 
 #rpc_host = internal-tuner.pandora.com


### PR DESCRIPTION
I was running Pianobar on KDE Neon and setting up the config using the example from the repo. I was editing the file with NeoVim and doing a copy/paste from the raw view of the file on Github and was seeing a complaint about "attempting to paste non-printable characters" during the paste. My hex is a bit scant right off the top of my head, but I think they were ESC characters.