### PR TITLE
Notify the user if they have the caps lock on and are trying to issue a valid command

### DIFF
--- a/src/ui_dispatch.c
+++ b/src/ui_dispatch.c
@@ -65,7 +65,7 @@ BarKeyShortcutId_t BarUiDispatch (BarApp_t *app, const char key, PianoStation_t 
 				return BAR_KS_COUNT;
 			}
 		} else if (app->settings.keys[i] != BAR_KS_DISABLED &&
-				app->settings.keys[i] == (key - 'a') &&
+				app->settings.keys[i] == (key - 'A' + 'a') &&
 				verbose) {
 			// if lower(key) is a valid command, gently notify the user
 			BarUiMsg(&app->settings, MSG_ERR, "Caps lock may be on, command not recognized\n");

--- a/src/ui_dispatch.c
+++ b/src/ui_dispatch.c
@@ -64,6 +64,11 @@ BarKeyShortcutId_t BarUiDispatch (BarApp_t *app, const char key, PianoStation_t 
 				}
 				return BAR_KS_COUNT;
 			}
+		} else if (app->settings.keys[i] != BAR_KS_DISABLED &&
+				app->settings.keys[i] == (key - 'a') &&
+				verbose) {
+			// if lower(key) is a valid command, gently notify the user
+			BarUiMsg(&app->settings, MSG_ERR, "Caps lock may be on, command not recognized\n");
 		}
 	}
 	return BAR_KS_COUNT;

--- a/src/ui_dispatch.c
+++ b/src/ui_dispatch.c
@@ -65,6 +65,7 @@ BarKeyShortcutId_t BarUiDispatch (BarApp_t *app, const char key, PianoStation_t 
 				return BAR_KS_COUNT;
 			}
 		} else if (app->settings.keys[i] != BAR_KS_DISABLED &&
+                key < 'a' && /* keep the next operation from overflowing */
 				app->settings.keys[i] == (key - 'A' + 'a') &&
 				verbose) {
 			// if lower(key) is a valid command, gently notify the user


### PR DESCRIPTION
Sometimes I forget I have the caps lock on and hit 'N' only for nothing to happen; short of modifying actual dispatch settings to duplicate the callbacks, I think this is a fair compromise in terms of user experience + leaving those shortcuts open for future use