### PR TITLE
docs: fix simple typo, exhaused -> exhausted

### DIFF
--- a/src/libpiano/response.c
+++ b/src/libpiano/response.c
@@ -77,7 +77,7 @@ static void PianoStrpcat (char * restrict dest, const char * restrict src,
 		--len;
 	}
 
-	/* append until source exhaused or destination full */
+	/* append until source exhausted or destination full */
 	while (*src != '\0' && len > 1) {
 		*dest = *src;
 		++dest;


### PR DESCRIPTION
There is a small typo in src/libpiano/response.c.

Should read `exhausted` rather than `exhaused`.

