### PR TITLE
Add config link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ pianobar is a console client for the personalized web radio [Pandora](https://ww
 * last.fm scrobbling support (external application)
 * Proxy support for listeners outside the USA.
 
+### Configuration
+Setup personal config by looking the following link: [config example](https://github.com/PromyLOPh/pianobar/blob/master/contrib/config-example)
+
 ### Source Code
 
 The source code can be downloaded at [github.com](https://github.com/PromyLOPh/pianobar)


### PR DESCRIPTION
related to #609 

Each get a new computer and install pianobar, I have to remember where the config file is located. 

If I have this problem I imagine other users also have this problem.

Happy to change the text/verbaige.
It seems this content should be in the readme instead of needing to check the source to find the sample config file.