### PR TITLE
Add PianobarNowPlayable as an external project

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,10 +181,13 @@ pianobar.el_
     Emacs interface for pianobar
 `pianobar-mediaplayer2`_
     Control pianobar like any other media player through DBUS/MPRIS.
+PianobarNowPlayable_
+    Integrate Pianobar with the Now Playing feature of macOS
 
 .. _control-pianobar: http://malabarba.github.io/control-pianobar/
 .. _pianobar.el: https://github.com/agrif/pianobar.el
 .. _pianobar-mediaplayer2: https://github.com/ryanswilson59/pianobar-mediaplayer2
+.. _PianobarNowPlayable: https://github.com/iDom818/PianobarNowPlayable
 
 Clients
 +++++++


### PR DESCRIPTION
I created a new project to integrate pianobar with the Now playing feature of macOS. Was hoping to add it to the external projects section here.