### PR TITLE
Update eventcmd docs

### DIFF
--- a/contrib/config-example
+++ b/contrib/config-example
@@ -23,7 +23,6 @@
 #act_stationaddbygenre = g
 #act_songinfo = i
 #act_addshared = j
-#act_songmove = m
 #act_songnext = n
 #act_songpause = S
 #act_songpausetoggle = p

--- a/contrib/pianobar.1
+++ b/contrib/pianobar.1
@@ -445,12 +445,13 @@ can report certain "events" to an external application (see
 information like error code and description, was well as song information
 related to the current event, is supplied through stdin.
 
-Currently supported events are: artistbookmark, songban, songbookmark,
-songexplain, songfinish, songlove, songshelf, songstart, stationaddgenre,
-stationaddmusic, stationaddshared, stationcreate, stationdelete,
-stationdeleteartistseed, stationdeletefeedback, stationdeletesongseed,
-stationfetchinfo, stationfetchplaylist, stationfetchgenre,
-stationquickmixtoggle, stationrename, userlogin, usergetstations
+Currently supported events are: artistbookmark, settingschange, settingsget,
+songban, songbookmark, songexplain, songfinish, songlove, songshelf, songstart,
+stationaddgenre, stationaddmusic, stationaddshared, stationcreate,
+stationdelete, stationdeleteartistseed, stationdeletefeedback,
+stationdeletesongseed, stationdeletestationseed, stationfetchgenre,
+stationfetchinfo, stationfetchplaylist, stationgetmodes, stationquickmixtoggle,
+stationrename, stationsetmode, usergetstations, userlogin
 
 An example script can be found in the contrib/ directory of
 .B pianobar's

--- a/contrib/pianobar.1
+++ b/contrib/pianobar.1
@@ -103,10 +103,6 @@ beginning.
 Delete artist/song seeds or feedback.
 
 .TP
-.B act_songmove = m
-Move current song to another station
-
-.TP
 .B act_songnext = n
 Skip current song.
 
@@ -450,12 +446,11 @@ information like error code and description, was well as song information
 related to the current event, is supplied through stdin.
 
 Currently supported events are: artistbookmark, songban, songbookmark,
-songexplain, songfinish, songlove, songmove, songshelf, songstart,
-stationaddgenre, stationaddmusic, stationaddshared, stationcreate,
-stationdelete, stationdeleteartistseed, stationdeletefeedback,
-stationdeletesongseed, stationfetchinfo, stationfetchplaylist,
-stationfetchgenre stationquickmixtoggle, stationrename, userlogin,
-usergetstations
+songexplain, songfinish, songlove, songshelf, songstart, stationaddgenre,
+stationaddmusic, stationaddshared, stationcreate, stationdelete,
+stationdeleteartistseed, stationdeletefeedback, stationdeletesongseed,
+stationfetchinfo, stationfetchplaylist, stationfetchgenre,
+stationquickmixtoggle, stationrename, userlogin, usergetstations
 
 An example script can be found in the contrib/ directory of
 .B pianobar's


### PR DESCRIPTION
This PR updates the eventcmd documentation by applying two fixes:
1. Remove references to the `songmove` eventcmd, which was still documented despite having been removed in 845cf4c (see #280).
2. Document the existence of the `settingschange`, `settingsget`, `stationdeletestationseed`,
`stationgetmodes`, and `stationsetmode` eventcmds. All of them are provided as arguments to [`BarUiActDefaultEventcmd`](https://github.com/PromyLOPh/pianobar/blob/237ac782779bd9b5152bb42ce2bf8deaaccbb5b5/src/ui_act.c#L40-L42) at some point.